### PR TITLE
feat: add new Ansible roles for Docker Login and Docker Compose

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,16 +18,15 @@ tags:
   - apt
   - containerd
   - linux
-  - windows
 
 dependencies:
   arillso.system: ">=0.0.17"
 
 repository: https://github.com/arillso/ansible.container
 
-documentation: https://github.com/arillso/ansible.container
+documentation: https://guide.arillso.io/collections/arillso/container/index.html
 
-# homepage: http://example.com
+homepage: https://arillso.io
 
 issues: https://github.com/arillso/ansible.container/issues
 

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -1,35 +1,43 @@
 # arillso.container.docker
 
-This Ansible role is designed for configuring and managing Docker environments using Ansible. It defines parameters for
-setting up Docker on various distributions, allowing for a customized Docker experience.
+This Ansible role is designed for the configuration and management of Docker environments.
+It offers tailored parameters for setting up Docker across various distributions, enabling a customized Docker experience.
 
 ## Requirements
 
-- Ansible 2.915 or higher.
-- Suitable access to target systems for Docker installation and configuration.
+- **Ansible Version**: 2.15 or higher
+- **Access**: Adequate permissions for Docker installation and configuration on target systems
 
 ## Role Variables
 
-The role uses various variables to customize Docker setup and behavior. These variables are defined in the `defaults/main.yml` file.
-Users can override these default values in their playbook.
+Variables for customizing Docker setup are defined in `defaults/main.yml`. Users can override these in their playbook. Key variables include:
 
 ### Docker Configuration
 
-- `docker_version`: Specifies the Docker version to install (default: latest).
-- `docker_daemon`: A dictionary to define Docker daemon configurations, including options like `log-driver` (default: "journald"),
-  `log-opts` (with options like `max-size`), `live-restore` (default: true), and `registry-mirrors`.
+- `docker_version`: Docker version to install (default: latest)
+- `docker_daemon`: Configuration dictionary for Docker daemon, including:
+  - `log-driver` (default: "journald")
+  - `log-opts` with options like `max-size`
+  - `live-restore` (default: true)
+  - `registry-mirrors`
 
 ### Systemd Units for Docker
 
-- `docker_systemd_units`: A list of systemd units for Docker pruning tasks, with options to specify the unit's name, type, and various systemd options.
+- `docker_systemd_units`: List of systemd units for Docker pruning tasks. Includes options for unit's name, type, and various systemd settings.
+
+## Documentation
+
+For detailed information and advanced usage, refer to our guide:
+
+[Arillso Docker Guide](https://guide.arillso.io/collections/arillso/container/docker.html#ansible-collections-arillso-container-docker-role)
 
 ## Dependencies
 
-No other Ansible roles are required as dependencies.
+This role is standalone and does not require other Ansible roles as dependencies.
 
 ## Example Playbook
 
-An example playbook demonstrating the use of `arillso.container.docker` to set up Docker:
+Example playbook for using `arillso.container.docker`:
 
 ```yaml
 - hosts: all

--- a/roles/docker/meta/argument_specs.yml
+++ b/roles/docker/meta/argument_specs.yml
@@ -8,7 +8,7 @@ argument_specs:
       docker_version:
         type: str
         description: Specifies the version of Docker to be installed. If omitted, the latest version is installed.
-        default: "{{ omit }}"
+        default: ""
 
       docker_daemon:
         type: dict

--- a/roles/docker_compose/README.md
+++ b/roles/docker_compose/README.md
@@ -1,0 +1,80 @@
+# arillso.container.docker_compose
+
+This Ansible role is tailored for the configuration and management of Docker Compose environments.
+It provides a customizable approach for Docker Compose setups across various systems.
+
+## Requirements
+
+- **Ansible Version**: 2.15 or higher
+- **Permissions**: Necessary rights to access and manage target systems
+
+## Role Variables
+
+Variables are defined in `defaults/main.yml` and can be overridden in your playbook for specific needs. Key variables include:
+
+### Docker Compose Configuration
+
+#### Argument Specifications
+
+- `docker_compose_version`: Specifies Docker Compose version to install (defaults to latest)
+- `docker_compose_package`: List of Docker Compose packages for installation
+- `docker_compose_directory_path`: Base directory path for Docker Compose configuration files
+- `docker_compose_directory`: Full path for the Docker Compose project directory
+- `docker_compose_use_file`: Boolean to choose between file-based or inline configuration
+- `docker_compose_config`: Inline Docker Compose configuration as YAML string
+- `docker_compose_project`: Name of the Docker Compose project
+- `docker_compose_api_version`: Docker API version ('auto' for automatic)
+- `docker_compose_build`: Option to build images before starting services
+- `docker_compose_ca_cert`: CA certificate path for server verification
+- `docker_compose_client_cert`: Client's TLS certificate path
+- `docker_compose_client_key`: Client's TLS key path
+- `docker_compose_debug`: Toggle for debug mode
+- `docker_compose_dependencies`: Include/exclude linked services
+- `docker_compose_docker_host`: Docker host URL or Unix socket path
+- `docker_compose_env_file`: Custom environment file path
+- `docker_compose_files`: Override default `docker-compose.yml` with a list of filenames
+- `docker_compose_hostname_check`: Check Docker daemon's hostname against client certificate
+- `docker_compose_nocache`: Control cache use during image build
+- `docker_compose_profiles`: Profiles to activate when starting services
+- `docker_compose_project_name`: Custom name for the Docker Compose project
+- `docker_compose_pull`: Always pull images before starting
+- `docker_compose_recreate`: Container recreation strategy ('always', 'never', 'smart')
+- `docker_compose_remove_images`: Remove images when state is 'absent'
+- `docker_compose_remove_orphans`: Remove containers not defined in Compose file
+- `docker_compose_remove_volumes`: Remove data volumes when state is 'absent'
+- `docker_compose_restarted`: Restart all containers when state is 'present'
+- `docker_compose_scale`: Service scaling configuration
+- `docker_compose_services`: List of specific services to operate on
+- `docker_compose_ssl_version`: SSL version for secure communication
+- `docker_compose_state`: Desired state of the Docker Compose project
+- `docker_compose_stopped`: Stop all containers when state is 'present'
+- `docker_compose_timeout`: Timeout for container shutdown operations (seconds)
+- `docker_compose_tls`: Use TLS for API connection without server authenticity verification
+- `docker_compose_tls_hostname`: Expected hostname for Docker Host server TLS verification
+- `docker_compose_use_ssh_client`: Enable SSH client for Docker API communication
+- `docker_compose_validate_certs`: Verify Docker host server authenticity with TLS
+
+## Documentation
+
+For detailed information and advanced usage, refer to our comprehensive guide:
+
+[Arillso Docker Compose Guide](https://guide.arillso.io/collections/arillso/container/docker_compose.html#ansible-collections-arillso-container-docker-compose-role)
+
+## Dependencies
+
+This role operates independently without external dependencies.
+
+## Example Playbook
+
+Example demonstrating this role's usage:
+
+```yaml
+- hosts: servers
+  become: true
+  roles:
+    - arillso.container.docker_compose
+  vars:
+    docker_compose_version: "1.29.2"
+    docker_compose_use_file: true
+    docker_compose_project: "my_project"
+```

--- a/roles/docker_compose/defaults/main.yml
+++ b/roles/docker_compose/defaults/main.yml
@@ -1,0 +1,111 @@
+# Specifies the version of Docker Compose to install. Leave blank for the latest version.
+docker_compose_version: ""
+
+# List of Docker Compose packages for installation. Appends the specified version to the package name if docker_compose_version is set.
+docker_compose_package:
+  - "{{ 'docker-compose-plugin=' + docker_compose_version if docker_compose_version != '' else 'docker-compose-plugin' }}"
+
+# Base directory path for storing Docker Compose configuration files.
+docker_compose_directory_path: "/etc/docker/compose"
+
+# Full path to the Docker Compose project directory, constructed from docker_compose_directory_path and docker_compose_project.
+docker_compose_directory: "{{ docker_compose_directory_path }}/{{ docker_compose_project }}"
+
+# Boolean flag to choose Docker Compose execution method: 'true' for file-based, 'false' for inline configuration.
+docker_compose_use_file: true
+
+# Inline configuration for Docker Compose, defined as an array of multi-line YAML strings.
+docker_compose_config: []
+
+# Name of the Docker Compose project, utilized to construct the full Docker Compose directory path.
+docker_compose_project: ""
+
+# Docker API version to use. Set to 'auto' for automatic selection of the latest supported version.
+docker_compose_api_version: "auto"
+
+# Option to build images before starting services. Set to 'true' to enable image building.
+docker_compose_build: false
+
+# Path to the CA certificate for server verification. If not set, default CA certificates are used.
+docker_compose_ca_cert: null
+
+# Path to the client's TLS certificate for Docker daemon communication.
+docker_compose_client_cert: null
+
+# Path to the client's TLS key for Docker daemon communication.
+docker_compose_client_key: null
+
+# Enable or disable debug mode. Set to 'true' to activate.
+docker_compose_debug: false
+
+# Include or exclude linked services. Set to 'true' to include.
+docker_compose_dependencies: true
+
+# Docker host URL or Unix socket path for API connection. Defaults to the standard Unix socket.
+docker_compose_docker_host: "unix://var/run/docker.sock"
+
+# Custom path to an environment file, relative to the project source directory.
+docker_compose_env_file: null
+
+# List of Compose file names, relative to project_src, to override default docker-compose.yml.
+docker_compose_files: null
+
+# Check Docker daemon's hostname against the name provided in the client certificate. Default is 'false'.
+docker_compose_hostname_check: false
+
+# Control the use of cache during the image build. Set to 'true' to ignore cache.
+docker_compose_nocache: false
+
+# List of profiles to enable when starting services, applicable for docker-compose v1.28.0 or later.
+docker_compose_profiles: null
+
+# Custom name for the Docker Compose project. If not set, the default name is derived from the project directory.
+docker_compose_project_name: null
+
+# Always pull images before starting the application. Set to 'true' to enable.
+docker_compose_pull: false
+
+# Strategy for container recreation: 'always', 'never', or 'smart' (default).
+docker_compose_recreate: "smart"
+
+# Option to remove images when state is 'absent'. Choices are 'all' or 'local'.
+docker_compose_remove_images: null
+
+# Remove containers for services not defined in the current Compose file. Default is 'false'.
+docker_compose_remove_orphans: false
+
+# Remove data volumes when state is 'absent'. Default is 'false'.
+docker_compose_remove_volumes: false
+
+# Restart all containers when state is 'present'. Default is 'false'.
+docker_compose_restarted: false
+
+# Dictionary defining service scaling: service name as key, number of containers as value.
+docker_compose_scale: null
+
+# List of specific services to operate on. If empty, applies to all services in the Compose file.
+docker_compose_services: null
+
+# Specify a valid SSL version number for secure communication. Uses the default value determined by the SSL Python module if not set.
+docker_compose_ssl_version: null
+
+# Desired state of the Docker Compose project: 'present' (default) or 'absent'.
+docker_compose_state: "present"
+
+# Stop all containers when state is 'present'. Default is 'false'.
+docker_compose_stopped: false
+
+# Timeout in seconds for container shutdown operations. Uses default docker-compose timeout if not set.
+docker_compose_timeout: null
+
+# Use TLS for API connection without verifying the Docker host server's authenticity. Default is 'false'.
+docker_compose_tls: false
+
+# Expected hostname of the Docker Host server for TLS verification. No default value.
+docker_compose_tls_hostname: null
+
+# Flag to enable SSH client usage for Docker API communication. Currently ignored.
+docker_compose_use_ssh_client: false
+
+# Verify the Docker host server's authenticity when using TLS. Default is 'false'.
+docker_compose_validate_certs: false

--- a/roles/docker_compose/meta/argument_specs.yml
+++ b/roles/docker_compose/meta/argument_specs.yml
@@ -1,0 +1,234 @@
+---
+argument_specs:
+  main:
+    short_description: Configure and manage Docker Compose environment using Ansible
+    description:
+      - This spec outlines parameters for configuring Docker Compose with Ansible.
+      - It includes Docker Compose version, package names, directory paths, configuration methods, and project name.
+
+    options:
+      docker_compose_version:
+        type: str
+        description:
+          - The desired Docker Compose version. Leave empty for the latest version.
+        default: ""
+
+      docker_compose_package:
+        type: list
+        elements: str
+        description:
+          - List of Docker Compose packages to install, appending the version if specified.
+        default:
+          - "{{ 'docker-compose-plugin=' + docker_compose_version if docker_compose_version != '' else 'docker-compose-plugin' }}"
+
+      docker_compose_directory_path:
+        type: str
+        description:
+          - Base path for Docker Compose configuration files.
+        default: "/etc/docker/compose"
+
+      docker_compose_directory:
+        type: str
+        description:
+          - Full path to the Docker Compose project directory.
+        default: "{{ docker_compose_directory_path }}/{{ docker_compose_project }}"
+
+      docker_compose_use_file:
+        type: bool
+        description:
+          - Flag to use a Docker Compose file (true) or inline configuration (false).
+        default: true
+
+      docker_compose_config:
+        type: raw
+        description:
+          - Inline Docker Compose configuration, defined as a multi-line YAML string.
+        default: []
+
+      docker_compose_project:
+        type: str
+        description:
+          - The name of the Docker Compose project, used in the full path construction.
+        default: ""
+
+      docker_compose_api_version:
+        type: str
+        description:
+          - Docker API version to use, set to 'auto' for automatic version selection.
+        default: "auto"
+
+      docker_compose_build:
+        type: bool
+        description:
+          - Option to build images before starting services.
+        default: false
+
+      docker_compose_ca_cert:
+        type: str
+        description:
+          - Path to the CA certificate for server verification.
+        default: null
+
+      docker_compose_client_cert:
+        type: str
+        description:
+          - Path to the client's TLS certificate for Docker communication.
+        default: null
+
+      docker_compose_client_key:
+        type: str
+        description:
+          - Path to the client's TLS key for Docker communication.
+        default: null
+
+      docker_compose_debug:
+        type: bool
+        description:
+          - Enable or disable debug mode.
+        default: false
+
+      docker_compose_dependencies:
+        type: bool
+        description:
+          - Include or exclude linked services.
+        default: true
+
+      docker_compose_docker_host:
+        type: str
+        description:
+          - Docker host URL or Unix socket path for API connection.
+        default: "unix://var/run/docker.sock"
+
+      docker_compose_env_file:
+        type: str
+        description:
+          - Custom path to an environment file.
+        default: null
+
+      docker_compose_files:
+        type: list
+        elements: str
+        description:
+          - List of Compose file names to override the default docker-compose.yml.
+        default: null
+
+      docker_compose_hostname_check:
+        type: bool
+        description:
+          - Check Docker daemon's hostname against client certificate.
+        default: false
+
+      docker_compose_nocache:
+        type: bool
+        description:
+          - Control the use of cache during image build.
+        default: false
+
+      docker_compose_profiles:
+        type: list
+        elements: str
+        description:
+          - List of profiles to enable when starting services.
+        default: null
+
+      docker_compose_project_name:
+        type: str
+        description:
+          - Custom name for the Docker Compose project.
+        default: null
+
+      docker_compose_pull:
+        type: bool
+        description:
+          - Always pull images before starting the application.
+        default: false
+
+      docker_compose_recreate:
+        type: str
+        description: "Strategy for container recreation: 'always', 'never', or 'smart'."
+        default: "smart"
+
+      docker_compose_remove_images:
+        type: str
+        description:
+          - Option to remove images when state is 'absent'.
+        default: null
+
+      docker_compose_remove_orphans:
+        type: bool
+        description:
+          - Remove containers for services not defined in the Compose file.
+        default: false
+
+      docker_compose_remove_volumes:
+        type: bool
+        description:
+          - Remove data volumes when state is 'absent'.
+        default: false
+
+      docker_compose_restarted:
+        type: bool
+        description:
+          - Restart all containers when state is 'present'.
+        default: false
+
+      docker_compose_scale:
+        type: dict
+        description:
+          - Dictionary defining service scaling.
+        default: null
+
+      docker_compose_services:
+        type: list
+        elements: str
+        description:
+          - List of specific services to operate on.
+        default: null
+
+      docker_compose_ssl_version:
+        type: str
+        description:
+          - Specify a valid SSL version number for secure communication.
+        default: null
+
+      docker_compose_state:
+        type: str
+        description:
+          - Desired state of the Docker Compose project.
+        default: "present"
+
+      docker_compose_stopped:
+        type: bool
+        description:
+          - Stop all containers when state is 'present'.
+        default: false
+
+      docker_compose_timeout:
+        type: int
+        description:
+          - Timeout in seconds for container shutdown operations.
+        default: null
+
+      docker_compose_tls:
+        type: bool
+        description:
+          - Use TLS for API connection without verifying Docker host server's authenticity.
+        default: false
+
+      docker_compose_tls_hostname:
+        type: str
+        description:
+          - Expected hostname of the Docker Host server for TLS verification.
+        default: null
+
+      docker_compose_use_ssh_client:
+        type: bool
+        description:
+          - Flag to enable SSH client usage for Docker API communication.
+        default: false
+
+      docker_compose_validate_certs:
+        type: bool
+        description:
+          - Verify the Docker host server's authenticity when using TLS.
+        default: false

--- a/roles/docker_compose/tasks/main.yml
+++ b/roles/docker_compose/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+- name: Install Docker Compose packages
+  become: true
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ docker_compose_packages }}"
+
+- name: Ensure Docker Compose directory exists with correct permissions
+  ansible.builtin.file:
+    path: "{{ docker_compose_yaml_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Manage Docker Compose Setup
+  when: docker_compose_config | length > 0
+  block:
+    - name: Configure Docker Compose environment
+      when: docker_compose_use_file
+      block:
+        - name: Set up Docker Compose systemd service on target host
+          ansible.builtin.template:
+            src: etc/systemd/system/docker-compose@.service.j2
+            dest: /etc/systemd/system/docker-compose@.service
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: Create Docker Compose configuration file from template
+          ansible.builtin.template:
+            src: etc/docker/compose/docker-compose.yml.j2
+            dest: "{{ docker_compose_directory_path }}/{{ docker_compose_project }}/docker-compose.yml"
+            owner: root
+            group: root
+            mode: "0644"
+
+    - name: Launch Docker Compose based on specified configuration
+      community.docker.docker_compose:
+        project_src: "{{ docker_compose_directory if docker_compose_use_file else omit }}"
+        definition: "{{ docker_compose_config if not docker_compose_use_file else omit }}"
+        api_version: "{{ docker_compose_api_version }}"
+        build: "{{ docker_compose_build }}"
+        ca_cert: "{{ docker_compose_ca_cert }}"
+        client_cert: "{{ docker_compose_client_cert }}"
+        client_key: "{{ docker_compose_client_key }}"
+        debug: "{{ docker_compose_debug }}"
+        dependencies: "{{ docker_compose_dependencies }}"
+        docker_host: "{{ docker_compose_docker_host }}"
+        env_file: "{{ docker_compose_env_file }}"
+        files: "{{ docker_compose_files }}"
+        hostname_check: "{{ docker_compose_hostname_check }}"
+        nocache: "{{ docker_compose_nocache }}"
+        profiles: "{{ docker_compose_profiles }}"
+        project_name: "{{ docker_compose_project_name }}"
+        pull: "{{ docker_compose_pull }}"
+        recreate: "{{ docker_compose_recreate }}"
+        remove_images: "{{ docker_compose_remove_images }}"
+        remove_orphans: "{{ docker_compose_remove_orphans }}"
+        remove_volumes: "{{ docker_compose_remove_volumes }}"
+        restarted: "{{ docker_compose_restarted }}"
+        scale: "{{ docker_compose_scale }}"
+        services: "{{ docker_compose_services }}"
+        ssl_version: "{{ docker_compose_ssl_version }}"
+        state: "{{ docker_compose_state }}"
+        stopped: "{{ docker_compose_stopped }}"
+        timeout: "{{ docker_compose_timeout }}"
+        tls: "{{ docker_compose_tls }}"
+        tls_hostname: "{{ docker_compose_tls_hostname }}"
+        use_ssh_client: "{{ docker_compose_use_ssh_client }}"
+        validate_certs: "{{ docker_compose_validate_certs }}"

--- a/roles/docker_compose/templates/etc/docker/compose/docker-compose.yml.j2
+++ b/roles/docker_compose/templates/etc/docker/compose/docker-compose.yml.j2
@@ -1,0 +1,1 @@
+{{ docker_compose_config }}

--- a/roles/docker_compose/templates/etc/systemd/system/docker-compose@.service.j2
+++ b/roles/docker_compose/templates/etc/systemd/system/docker-compose@.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=%i service with docker compose
+PartOf=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+WorkingDirectory={{ docker_compose_directory_path }}/%i
+ExecStart=/usr/local/bin/docker-compose up -d --remove-orphans
+ExecStop=/usr/local/bin/docker-compose down
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/docker_login/README.md
+++ b/roles/docker_login/README.md
@@ -1,0 +1,55 @@
+# arillso.container.docker_login
+
+This Ansible role facilitates Docker registry logins, offering a streamlined authentication process with customizable settings for various environments.
+
+## Requirements
+
+- **Ansible Version**: 2.15 or higher
+- **Permissions**: Adequate rights to manage Docker configurations on target machines
+
+## Role Variables
+
+Defined in `defaults/main.yml`, these variables can be customized in your playbook. Key variables include:
+
+- `docker_login_api_version`: Docker API version
+- `docker_login_ca_cert`: CA certificate path for server verification
+- `docker_login_client_cert`: Client's TLS certificate path
+- `docker_login_client_key`: Client's TLS key path
+- `docker_login_config_path`: Custom path for Docker CLI configuration
+- `docker_login_debug`: Debug mode toggle
+- `docker_login_docker_host`: Docker API connection URL or Unix socket
+- `docker_login_password`: Registry account password (plaintext)
+- `docker_login_reauthorize`: Refresh existing authentication token
+- `docker_login_registry_url`: Docker registry URL
+- `docker_login_ssl_version`: SSL version for secure communication
+- `docker_login_state`: User state ('present' or 'absent')
+- `docker_login_timeout`: API response timeout (seconds)
+- `docker_login_tls`: Toggle for TLS in API connection
+- `docker_login_tls_hostname`: Expected Docker Host server name for TLS
+- `docker_login_username`: Registry account username
+- `docker_login_validate_certs`: Docker host server authenticity verification
+
+## Documentation
+
+For detailed information and advanced usage, refer to our comprehensive guide, covering topics like advanced configurations, best practices, and troubleshooting.
+
+[Arillso Docker Login Guide](https://guide.arillso.io/collections/arillso/container/docker_login.html#ansible-collections-arillso-container-ocker-login-role)
+
+## Dependencies
+
+This role is self-contained with no external dependencies.
+
+## Example Playbook
+
+An example of using this role:
+
+```yaml
+- hosts: docker
+  become: true
+  roles:
+    - arillso.container.docker_login
+  vars:
+    docker_login_username: "user123"
+    docker_login_password: "password"
+    docker_login_registry_url: "https://myregistry.com"
+```

--- a/roles/docker_login/defaults/main.yml
+++ b/roles/docker_login/defaults/main.yml
@@ -1,0 +1,54 @@
+---
+# Docker API version to use. Set to 'auto' for automatic selection of the latest supported version.
+docker_login_api_version: "auto"
+
+# Path to a CA certificate file for server verification.
+docker_login_ca_cert: "{{ omit }}"
+
+# Path to the client's TLS certificate file.
+docker_login_client_cert: "{{ omit }}"
+
+# Path to the client's TLS key file.
+docker_login_client_key: "{{ omit }}"
+
+# Custom path to the Docker CLI configuration file.
+docker_login_config_path: "~/.docker/config.json"
+
+# Enable or disable debug mode. Set to 'true' to activate.
+docker_login_debug: false
+
+# Docker host URL or Unix socket path for API connection. Defaults to the standard Unix socket.
+docker_login_docker_host: "unix://var/run/docker.sock"
+
+# The plaintext password for the registry account.
+docker_login_password: ""
+
+# Refresh existing authentication in the configuration file.
+docker_login_reauthorize: false
+
+# The registry URL.
+docker_login_registry_url: "https://index.docker.io/v1/"
+
+# Specify a valid SSL version number for secure communication.
+docker_login_ssl_version: "{{ omit }}"
+
+# Controls the current state of the user. 'present' to login, 'absent' to log out.
+docker_login_state: "present"
+
+# Maximum time in seconds to wait for a response from the API.
+docker_login_timeout: 60
+
+# Secures connection to the API using TLS without verifying Docker host server.
+docker_login_tls: false
+
+# Expected name of the Docker Host server for authenticity verification.
+docker_login_tls_hostname: "{{ omit }}"
+
+# Use the SSH CLI tool instead of paramiko for SSH transports. Currently ignored.
+docker_login_use_ssh_client: false
+
+# Username for the registry account.
+docker_login_username: ""
+
+# Secures the connection to the API by using TLS and verifying the Docker host server authenticity.
+docker_login_validate_certs: false

--- a/roles/docker_login/meta/argument_specs.yml
+++ b/roles/docker_login/meta/argument_specs.yml
@@ -1,0 +1,116 @@
+---
+argument_specs:
+  main:
+    short_description: Manage Docker registry login using Ansible
+    description:
+      - This spec outlines parameters for managing Docker registry logins with Ansible.
+      - It includes options for Docker API version, server verification certificates, and Docker host connection settings, along with login credentials.
+
+    options:
+      docker_login_api_version:
+        type: str
+        description:
+          - Docker API version to use, set to 'auto' for automatic version selection.
+        default: "auto"
+
+      docker_login_ca_cert:
+        type: str
+        description:
+          - Path to the CA certificate for server verification.
+        default: "{{ omit }}"
+
+      docker_login_client_cert:
+        type: str
+        description:
+          - Path to the client's TLS certificate for Docker daemon communication.
+        default: "{{ omit }}"
+
+      docker_login_client_key:
+        type: str
+        description:
+          - Path to the client's TLS key for Docker daemon communication.
+        default: "{{ omit }}"
+
+      docker_login_config_path:
+        type: str
+        description:
+          - Custom path to the Docker CLI configuration file.
+        default: "~/.docker/config.json"
+
+      docker_login_debug:
+        type: bool
+        description:
+          - Enable or disable debug mode.
+        default: false
+
+      docker_login_docker_host:
+        type: str
+        description:
+          - Docker host URL or Unix socket path for API connection.
+        default: "unix://var/run/docker.sock"
+
+      docker_login_password:
+        type: str
+        description:
+          - The plaintext password for the registry account.
+        default: ""
+
+      docker_login_reauthorize:
+        type: bool
+        description:
+          - Refresh existing authentication in the configuration file.
+        default: false
+
+      docker_login_registry_url:
+        type: str
+        description:
+          - The registry URL.
+        default: "https://index.docker.io/v1/"
+
+      docker_login_ssl_version:
+        type: str
+        description:
+          - Specify a valid SSL version number for secure communication.
+        default: "{{ omit }}"
+
+      docker_login_state:
+        type: str
+        description:
+          - Controls the current state of the user. 'present' to login, 'absent' to log out.
+        default: "present"
+
+      docker_login_timeout:
+        type: int
+        description:
+          - Maximum time in seconds to wait for a response from the API.
+        default: 60
+
+      docker_login_tls:
+        type: bool
+        description:
+          - Secures connection to the API using TLS without verifying Docker host server.
+        default: false
+
+      docker_login_tls_hostname:
+        type: str
+        description:
+          - Expected name of the Docker Host server for authenticity verification.
+        default: "{{ omit }}"
+
+      docker_login_use_ssh_client:
+        type: bool
+        description:
+          - Use the SSH CLI tool instead of paramiko for SSH transports. Currently ignored.
+        default: false
+
+      docker_login_username:
+        type: str
+        description:
+          - Username for the registry account.
+        default: ""
+
+      docker_login_validate_certs:
+        type: bool
+        description:
+          - Secures the connection to the API by using TLS and verifying the Docker host server authenticity.
+        default: false

--- a/roles/docker_login/tasks/main.yml
+++ b/roles/docker_login/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Login to Docker registry
+  community.docker.docker_login:
+    api_version: "{{ docker_login_api_version }}"
+    ca_cert: "{{ docker_login_ca_cert }}"
+    client_cert: "{{ docker_login_client_cert }}"
+    client_key: "{{ docker_login_client_key }}"
+    debug: "{{ docker_login_debug }}"
+    docker_host: "{{ docker_login_docker_host }}"
+    email: "{{ docker_login_email }}"
+    password: "{{ docker_login_password }}"
+    reauthorize: "{{ docker_login_reauthorize }}"
+    registry_url: "{{ docker_login_registry_url }}"
+    ssl_version: "{{ docker_login_ssl_version }}"
+    timeout: "{{ docker_login_timeout }}"
+    tls: "{{ docker_login_tls }}"
+    tls_hostname: "{{ docker_login_tls_hostname }}"
+    tls_verify: "{{ docker_login_tls_verify }}"
+    username: "{{ docker_login_username }}"


### PR DESCRIPTION
### Added
- **Docker Login Role**: New Ansible role for managing Docker login operations. Includes tasks, templates, and default variables specific to Docker login configurations and execution.
- **Docker Compose Role**: New Ansible role for Docker Compose management, comprising tasks, templates, defaults, and README documentation for Docker Compose environments.

### Changed
- Updated README files for Docker and Docker Compose roles with detailed information on role purpose, requirements, variables, and example usage.

### Fixed
- Corrected documentation links to updated web addresses.
- Refined role variable definitions and descriptions for improved clarity and precision.