### PR TITLE
fix: docker compse v2 scale

### DIFF
--- a/roles/docker_compose_v2/defaults/main.yml
+++ b/roles/docker_compose_v2/defaults/main.yml
@@ -84,7 +84,7 @@ docker_compose_v2_remove_volumes: false
 docker_compose_v2_restarted: false
 
 # Dictionary defining service scaling: service name as key, number of containers as value.
-docker_compose_v2_scale: "{{ omit }}"
+# docker_compose_v2_scale: "{{ omit }}"
 
 # List of specific services to operate on. If empty, applies to all services in the Compose file.
 docker_compose_v2_services: "{{ omit }}"

--- a/roles/docker_compose_v2/tasks/main.yml
+++ b/roles/docker_compose_v2/tasks/main.yml
@@ -70,7 +70,7 @@
         client_key: "{{ docker_compose_v2_client_key }}"
         files: "{{ docker_compose_v2_files }}"
         pull: "{{ docker_compose_v2_pull }}"
-        scale: "{{ docker_compose_v2_scale }}"
+        scale: "{{ docker_compose_v2_scale | default(omit) }}"
         services: "{{ docker_compose_v2_services }}"
 
   rescue:


### PR DESCRIPTION
## Changed

- **Docker_Compose_v2 Role:**
  - Documented the viewing of changes without any direct content alterations in `roles/docker_compose_v2/defaults/main.yml`.
  - Modified the `scale` option in `roles/docker_compose_v2/tasks/main.yml` to use a default filter, allowing for omission if not specified. This change adds flexibility to service scaling configurations by enabling more dynamic adjustment based on provided or omitted parameters.
