### PR TITLE
docs: add meta

### DIFF
--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  author: "arillso (@arillso)"
+  description: "Installs and configures Docker on Debian, RedHat, and Ubuntu."
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+    - name: Ubuntu
+      versions:
+        - focal
+    - name: RedHat
+      versions:
+        - "7"
+        - "8"
+
+  galaxy_tags:
+    - docker
+    - container
+    - deployment

--- a/roles/docker_compose/meta/main.yml
+++ b/roles/docker_compose/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  author: "arillso (@arillso)"
+  description: "Installs and configures Docker Compose on Debian, RedHat, and Ubuntu."
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+    - name: Ubuntu
+      versions:
+        - focal
+    - name: RedHat
+      versions:
+        - "7"
+        - "8"
+
+  galaxy_tags:
+    - docker
+    - compose
+    - deployment

--- a/roles/docker_compose_v2/meta/main.yml
+++ b/roles/docker_compose_v2/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  author: "arillso (@arillso)"
+  description: "Installs and configures Docker Compose 2 on Debian, RedHat, and Ubuntu."
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+    - name: Ubuntu
+      versions:
+        - focal
+    - name: RedHat
+      versions:
+        - "7"
+        - "8"
+
+  galaxy_tags:
+    - docker
+    - compose
+    - deployment

--- a/roles/docker_login/meta/main.yml
+++ b/roles/docker_login/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  author: "arillso (@arillso)"
+  description: "Logs into Docker registries on Debian, RedHat, and Ubuntu."
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+    - name: Ubuntu
+      versions:
+        - focal
+    - name: RedHat
+      versions:
+        - "7"
+        - "8"
+
+  galaxy_tags:
+    - docker
+    - login
+    - registry
+    - authentication


### PR DESCRIPTION

## Changed

- **New Role Metadata Added**:
  - **Docker Role (`roles/docker/meta/main.yml`)**:
    - Added new metadata file with details about the author, description, license, minimum Ansible version required, supported platforms (Debian, RedHat, Ubuntu), and tags (docker, container, deployment). This enhancement aims to improve the role's discoverability and usability across different environments.
  
  - **Docker_Compose Role (`roles/docker_compose/meta/main.yml`)**:
    - Introduced a metadata file similar to the Docker role, specifying the role's purpose to install and configure Docker Compose. It includes similar metadata fields, tailored for Docker Compose, including tags specific to docker and compose, highlighting the role's focus on deployment utilities.

  - **Docker_Compose_v2 Role (`roles/docker_compose_v2/meta/main.yml`)**:
    - Created a new metadata file to detail the installation and configuration of Docker Compose 2. This file shares the structure with the previous roles but is specific to Docker Compose 2, indicating a forward-looking approach to supporting newer versions.

  - **Docker_Login Role (`roles/docker_login/meta/main.yml`)**:
    - Added metadata for a role dedicated to logging into Docker registries. This file extends the consistency in role documentation, including specific tags for docker, login, registry, and authentication, which are crucial for managing Docker registry interactions securely.
