### PR TITLE
fix(k3s): Correct handler name case mismatch causing restart failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-03-20
+
+### Fixed
+
+- Fixed k3s role handler name case mismatch: `restart k3s` → `Restart k3s` causing deployment failures when k3s binary or config changes trigger a service restart
+
 ## [1.3.0] - 2026-03-19
 
 ### Added

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: container
-version: 1.3.0
+version: 1.3.1
 readme: README.md
 
 authors:

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -182,7 +182,7 @@
   when: >-
       not ansible_local.k3s.service.binary_installed | bool
       or ansible_local.k3s.service.version != k3s_version
-  notify: restart k3s
+  notify: Restart k3s
 
 - name: Create k3s configuration directory
   ansible.builtin.file:
@@ -215,7 +215,7 @@
       owner: root
       group: root
   become: true
-  notify: restart k3s
+  notify: Restart k3s
 
 - name: Create k3s registries config
   ansible.builtin.template:
@@ -226,7 +226,7 @@
       group: root
   become: true
   when: k3s_private_registries | length > 0
-  notify: restart k3s
+  notify: Restart k3s
 
 - name: Create k3s systemd service
   ansible.builtin.template:


### PR DESCRIPTION
Ansible handler names are case-sensitive. Three `notify` calls in `roles/k3s/tasks/main.yml` referenced `restart k3s` (lowercase) while the handler was defined as `Restart k3s` (uppercase R). This caused the playbook to abort with:

```
[ERROR]: The requested handler 'restart k3s' was not found in either the main handlers list nor in the listening handlers list
```

The error surfaced during deployments whenever the k3s binary or config was changed (e.g. version upgrade), because those tasks notify the restart handler. Tasks that were not changed ran fine, which made the failure appear intermittent.

Bumps version to 1.3.1.