### PR TITLE
fix(tailscale): Add missing meta/main.yml for Galaxy import

### DIFF
--- a/roles/tailscale/meta/main.yml
+++ b/roles/tailscale/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+    author: "arillso (@arillso)"
+    description: "Manages Tailscale Kubernetes resources including ProxyGroups, Ingress, and Egress services."
+    license: MIT
+    min_ansible_version: "2.15"
+    platforms:
+        - name: Ubuntu
+          versions:
+              - focal
+              - jammy
+        - name: Debian
+          versions:
+              - bullseye
+              - bookworm
+        - name: EL
+          versions:
+              - "8"
+              - "9"
+    galaxy_tags:
+        - tailscale
+        - kubernetes
+        - container
+        - networking

--- a/roles/tailscale/meta/main.yml
+++ b/roles/tailscale/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
-    author: "arillso (@arillso)"
+    role_name: tailscale
+    author: Arillso Team
     description: "Manages Tailscale Kubernetes resources including ProxyGroups, Ingress, and Egress services."
     license: MIT
     min_ansible_version: "2.15"
@@ -22,3 +23,6 @@ galaxy_info:
         - kubernetes
         - container
         - networking
+        - vpn
+
+dependencies: []


### PR DESCRIPTION
The tailscale role was missing `meta/main.yml`, which caused a Galaxy import
warning on every publish: *"Could not get role description, no role metadata found"*.

All other roles in the collection (`docker`, `k3s`, `helm`, `fleet`, `docker_compose_v2`,
`docker_login`) already have this file. This adds the equivalent for tailscale with
`galaxy_info` including description, license, supported platforms, and tags.