### PR TITLE
chore: update CHANGELOG.md for 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-03-21
+
+### Fixed
+
+- Fixed missing `meta/main.yml` in tailscale role causing Galaxy import warning "Could not get role description, no role metadata found" (#57)
+- Added missing AppArmor proc rules for containerd: `/proc/thread-self/mountinfo r` and `/proc/*/net/** r` to prevent AppArmor denials in k3s role (#58)
+
 ## [1.3.2] - 2026-03-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.3] - 2026-03-21
+## [1.3.3] - 2026-03-20
 
 ### Fixed
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: container
-version: 1.3.2
+version: 1.3.3
 readme: README.md
 
 authors:


### PR DESCRIPTION
Add `[1.3.3]` section documenting the two fixes merged since `1.3.2`:

- **#57** — tailscale role missing `meta/main.yml` (Galaxy import warning)
- **#58** — k3s AppArmor missing `/proc/thread-self/mountinfo` and `/proc/*/net/**` rules