### PR TITLE
fix(k3s): Add AppArmor rule for proc/thread-self/attr to allow containerd exec profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.7] - 2026-03-21
+
+### Fixed
+
+- Added AppArmor rule `/proc/thread-self/attr/** rw` to k3s security profile; required for containerd to apply AppArmor profiles to container exec processes (`apparmor failed to apply profile: write /proc/thread-self/attr/apparmor/exec: operation not permitted`)
+
 ## [1.3.6] - 2026-03-21
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: container
-version: 1.3.6
+version: 1.3.7
 readme: README.md
 
 authors:

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -173,6 +173,7 @@
                   # Process and system info (broad /proc/** needed for containerd/kubelet)
                   /proc/** r,
                   /proc/thread-self/fd/** rw,
+                  /proc/thread-self/attr/** rw,
                   /proc/sys/fs/pipe-max-size r,
                   /etc/machine-id r,
                   /sys/devices/virtual/dmi/id/product_uuid r,

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -173,7 +173,7 @@
                   # Process and system info (broad /proc/** needed for containerd/kubelet)
                   /proc/** r,
                   /proc/thread-self/fd/** rw,
-                  /proc/thread-self/attr/** rw,
+                  /proc/thread-self/attr/apparmor/** rw,  # containerd reads/writes AppArmor exec profile via this path
                   /proc/sys/fs/pipe-max-size r,
                   /etc/machine-id r,
                   /sys/devices/virtual/dmi/id/product_uuid r,


### PR DESCRIPTION
## Summary

- Added `/proc/thread-self/attr/** rw` to the k3s AppArmor profile
- Without this rule, containerd fails to apply AppArmor profiles to container exec processes with: `apparmor failed to apply profile: write /proc/thread-self/attr/apparmor/exec: operation not permitted`

## Root Cause

When containerd executes a process inside a container and tries to apply an AppArmor profile, it writes to `/proc/thread-self/attr/apparmor/exec`. The k3s AppArmor profile only had `/proc/** r` (read-only) and `/proc/thread-self/fd/** rw`, leaving the `attr/` subtree read-only.

## Test plan

- [ ] Verify `kubectl exec` into pods works without AppArmor errors
- [ ] Confirm containerd can apply profiles to container exec processes