### PR TITLE
fix(k3s,docker): add fsmount AppArmor rule and move Docker GPG key to keyrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.8] - 2026-03-28
+
+### Fixed
+
+- Added `fsmount,` AppArmor rule to k3s security profile; required for AppArmor 4.x (kernel >= 6.x) where containerd writes the AppArmor exec profile via the `fsmount` LSM hook when applying profiles to container processes (`apparmor failed to apply profile: write fsmount:fscontext:proc/thread-self/attr/apparmor/exec: operation not permitted`)
+- Moved Docker GPG key from deprecated `/etc/apt/trusted.gpg.d/` to `/etc/apt/keyrings/` and added task to create the keyrings directory; fixes apt warnings on Ubuntu 22.04+ that treat keys outside `/etc/apt/keyrings/` as untrusted
+
 ## [1.3.7] - 2026-03-21
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: container
-version: 1.3.7
+version: 1.3.8
 readme: README.md
 
 authors:

--- a/roles/docker/tasks/install_docker_ubuntu.yml
+++ b/roles/docker/tasks/install_docker_ubuntu.yml
@@ -1,9 +1,16 @@
 ---
 - name: "Ubuntu : create keyrings directory"
+  become: true
   ansible.builtin.file:
       path: /etc/apt/keyrings
       state: directory
       mode: "0755"
+
+- name: "Ubuntu : remove legacy GPG key"
+  become: true
+  ansible.builtin.file:
+      path: /etc/apt/trusted.gpg.d/docker.asc
+      state: absent
 
 - name: "Ubuntu : add key"
   ansible.builtin.get_url:

--- a/roles/docker/tasks/install_docker_ubuntu.yml
+++ b/roles/docker/tasks/install_docker_ubuntu.yml
@@ -1,8 +1,14 @@
 ---
+- name: "Ubuntu : create keyrings directory"
+  ansible.builtin.file:
+      path: /etc/apt/keyrings
+      state: directory
+      mode: "0755"
+
 - name: "Ubuntu : add key"
   ansible.builtin.get_url:
       url: "https://download.docker.com/linux/ubuntu/gpg"
-      dest: /etc/apt/trusted.gpg.d/docker.asc
+      dest: /etc/apt/keyrings/docker.asc
       mode: "0644"
       force: false
 
@@ -10,7 +16,7 @@
   become: true
   ansible.builtin.apt_repository:
       repo: >
-          deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/docker.asc]
+          deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
           https://download.docker.com/linux/{{ ansible_distribution | lower }}
           {{ ansible_distribution_release }} stable
       state: present

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -205,6 +205,10 @@
                   mount,
                   umount,
                   pivot_root,
+
+                  # Required for AppArmor 4.x (kernel >= 6.x): containerd writes AppArmor
+                  # exec profile via fsmount LSM hook when applying profiles to containers
+                  fsmount,
                 }
             dest: /etc/apparmor.d/k3s
             mode: "0644"


### PR DESCRIPTION
Prepare release 1.3.8 with two bug fixes surfaced during testing on Ubuntu 24.04 / kernel 6.x hosts.

**AppArmor 4.x fsmount rule (k3s)**

On kernel >= 6.x with AppArmor 4.x, containerd no longer writes the AppArmor exec profile via a regular file write to `/proc/thread-self/attr/apparmor/exec`. Instead it goes through the `fsmount` LSM hook, which the existing `/proc/thread-self/attr/apparmor/** rw` file rule does not cover. This caused `docker exec` (and K3s container starts) to fail with:

```
apparmor failed to apply profile: write fsmount:fscontext:proc/thread-self/attr/apparmor/exec: operation not permitted
```

Adding `fsmount,` to the k3s AppArmor profile resolves this.

**Docker GPG key path (docker role)**

The Docker GPG key was stored in `/etc/apt/trusted.gpg.d/`, which Ubuntu 22.04+ considers a legacy/untrusted location. Moved to `/etc/apt/keyrings/` (the modern convention) and added an explicit task to create that directory first, as it may not exist on minimal installs.