### PR TITLE
fix(k3s): replace invalid fsmount rule with change_profile for AppArmor exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.9] - 2026-03-28
+
+### Fixed
+
+- Replaced invalid `fsmount,` AppArmor rule (parse error: `unexpected TOK_END_OF_RULE, expecting TOK_MODE`) with `change_profile -> **,` in k3s security profile; this allows containerd to write the target profile name to `/proc/thread-self/attr/apparmor/exec` before exec, which is how AppArmor profiles are applied to container processes
+
 ## [1.3.8] - 2026-03-28
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: container
-version: 1.3.8
+version: 1.3.9
 readme: README.md
 
 authors:

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -206,9 +206,10 @@
                   umount,
                   pivot_root,
 
-                  # Required for AppArmor 4.x (kernel >= 6.x): containerd writes AppArmor
-                  # exec profile via fsmount LSM hook when applying profiles to containers
-                  fsmount,
+                  # Required for containerd to apply AppArmor profiles to container processes:
+                  # containerd writes the target profile name to /proc/thread-self/attr/apparmor/exec
+                  # before exec; change_profile allows transitioning to any profile on exec
+                  change_profile -> **,
                 }
             dest: /etc/apparmor.d/k3s
             mode: "0644"


### PR DESCRIPTION
Fixes a parse error introduced in 1.3.8 where `fsmount,` was added to the k3s AppArmor profile as a standalone rule.

`fsmount` is not a valid AppArmor rule keyword without a mode — `apparmor_parser` fails with:
```
syntax error, unexpected TOK_END_OF_RULE, expecting TOK_MODE
```

The correct rule for allowing containerd to apply AppArmor profiles to container processes is `change_profile -> **,`. This allows the k3s process to transition to any AppArmor profile at exec time, which is how containerd sets the security profile on a new container — by writing the target profile name to `/proc/thread-self/attr/apparmor/exec` before exec.

Bumps version to 1.3.9.