### PR TITLE
fix(k3s): deploy cri-containerd AppArmor profile with change_profile rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.10] - 2026-03-28
+
+### Fixed
+
+- Deploy `/etc/apparmor.d/cri-containerd.apparmor.d` with `change_profile -> **,` in k3s role;
+  on Ubuntu 24.04 (kernel 6.8, AppArmor 4.x) containerd generates this profile dynamically
+  without the rule, causing `kubectl exec` to fail with
+  `apparmor failed to apply profile: write fsmount:fscontext:proc/thread-self/attr/apparmor/exec:
+  operation not permitted`. Pre-deploying the fixed profile ensures runc can apply AppArmor
+  profiles to exec'd container processes.
+
 ## [1.3.9] - 2026-03-28
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: container
-version: 1.3.9
+version: 1.3.10
 readme: README.md
 
 authors:

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -129,6 +129,63 @@
         become: true
         when: ansible_os_family == "Debian"
 
+      - name: Deploy cri-containerd AppArmor profile with change_profile support
+        ansible.builtin.copy:
+            content: |
+                #include <tunables/global>
+
+                profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
+
+                  #include <abstractions/base>
+
+                  network,
+                  capability,
+                  file,
+                  umount,
+
+                  # Host (privileged) processes may send signals to container processes.
+                  signal (receive) peer=unconfined,
+                  # Manager may send signals to container processes.
+                  signal (receive) peer=cri-containerd.apparmor.d,
+
+                  deny @{PROC}/* w,
+                  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+                  deny @{PROC}/sys/[^k]** w,
+                  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,
+                  deny @{PROC}/sysrq-trigger rwklx,
+                  deny @{PROC}/mem rwklx,
+                  deny @{PROC}/kmem rwklx,
+                  deny @{PROC}/kcore rwklx,
+
+                  deny mount,
+
+                  deny /sys/[^f]*/** wklx,
+                  deny /sys/f[^s]*/** wklx,
+                  deny /sys/fs/[^c]*/** wklx,
+                  deny /sys/fs/c[^g]*/** wklx,
+                  deny /sys/fs/cg[^r]*/** wklx,
+                  deny /sys/firmware/** rwklx,
+                  deny /sys/kernel/security/** rwklx,
+
+                  ptrace (trace,read,tracedby,readby) peer=cri-containerd.apparmor.d,
+
+                  # Required for AppArmor 4.x (kernel >= 6.8): allows runc to apply
+                  # AppArmor profiles to exec'd container processes via
+                  # /proc/thread-self/attr/apparmor/exec (blocked without this on Ubuntu 24.04+)
+                  change_profile -> **,
+
+                }
+            dest: /etc/apparmor.d/cri-containerd.apparmor.d
+            mode: "0644"
+        become: true
+        register: cri_containerd_profile_updated
+
+      - name: Reload cri-containerd AppArmor profile
+        ansible.builtin.command: apparmor_parser -r /etc/apparmor.d/cri-containerd.apparmor.d
+        become: true
+        when: cri_containerd_profile_updated is changed
+        changed_when: true
+
       - name: Create AppArmor profile for K3s
         ansible.builtin.copy:
             content: |

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -132,6 +132,8 @@
       - name: Deploy cri-containerd AppArmor profile with change_profile support
         ansible.builtin.copy:
             content: |
+                # Based on containerd default profile — review on major containerd upgrades.
+                # change_profile -> **, added for AppArmor 4.x (kernel >= 6.8) compatibility.
                 #include <tunables/global>
 
                 profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
@@ -181,7 +183,9 @@
         register: cri_containerd_profile_updated
 
       - name: Reload cri-containerd AppArmor profile
-        ansible.builtin.command: apparmor_parser -r /etc/apparmor.d/cri-containerd.apparmor.d
+        ansible.builtin.shell: >
+            apparmor_parser -r /etc/apparmor.d/cri-containerd.apparmor.d ||
+            apparmor_parser /etc/apparmor.d/cri-containerd.apparmor.d
         become: true
         when: cri_containerd_profile_updated is changed
         changed_when: true


### PR DESCRIPTION
Fix `kubectl exec` failures on Ubuntu 24.04 (kernel 6.8, AppArmor 4.x).

**Root cause:** containerd generates the `cri-containerd.apparmor.d` AppArmor profile
dynamically at startup. The generated profile does not include `change_profile -> **,`.
On kernel 6.8 with AppArmor 4.x, writing to `/proc/thread-self/attr/apparmor/exec`
(which runc uses to apply an AppArmor profile to an exec'd container process) is now
mediated via the `change_profile` rule — not as a plain file write. Without this rule
the write returns EPERM and exec fails:

```
apparmor failed to apply profile: write fsmount:fscontext:proc/thread-self/attr/apparmor/exec:
operation not permitted
```

**Fix:** Pre-deploy `/etc/apparmor.d/cri-containerd.apparmor.d` with `change_profile -> **,`
added to the standard containerd default profile. AppArmor loads this on boot; containerd
detects the profile is already loaded at startup and skips re-generating it, so the fixed
version is used for all containers.

Verified on the affected node by manually deploying the profile and confirming exec works.

Bumps version to 1.3.10.