### PR TITLE
fix(k3s): allow all signal operations in AppArmor profile for pod termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.11] - 2026-03-31
+
+### Fixed
+
+- Replaced restrictive AppArmor signal rules (`signal (receive) peer=unconfined` and `signal (receive) peer=cri-containerd.apparmor.d`) with unrestricted `signal,` in k3s security profile; runc requires full signal capabilities (send/receive) to deliver SIGTERM/SIGKILL to container init processes during pod termination
+
 ## [1.3.10] - 2026-03-28
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: container
-version: 1.3.10
+version: 1.3.11
 readme: README.md
 
 authors:

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -145,10 +145,9 @@
                   file,
                   umount,
 
-                  # Host (privileged) processes may send signals to container processes.
-                  signal (receive) peer=unconfined,
-                  # Manager may send signals to container processes.
-                  signal (receive) peer=cri-containerd.apparmor.d,
+                  # Allow all signal operations (send/receive) — required for runc to
+                  # signal container init processes (SIGTERM/SIGKILL) during pod termination.
+                  signal,
 
                   deny @{PROC}/* w,
                   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,


### PR DESCRIPTION
## Summary

- Replaced restrictive AppArmor signal rules (`signal (receive) peer=unconfined` and `signal (receive) peer=cri-containerd.apparmor.d`) with unrestricted `signal,` — required for runc to send SIGTERM/SIGKILL to container init processes during pod termination
- Bumped version to 1.3.11 and updated CHANGELOG.md

## Test plan

- [ ] Deploy k3s with AppArmor enabled on Ubuntu 24.04
- [ ] Verify pod termination works correctly (`kubectl delete pod`)
- [ ] Verify no AppArmor denials in `dmesg` related to signal operations