### PR TITLE
fix(k3s): restrict AppArmor signal rules to specific peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.12] - 2026-04-01
+
+### Changed
+
+- Reverted unrestricted `signal,` AppArmor rule back to targeted peer-specific rules (`signal (receive) peer=unconfined` and `signal (receive) peer=cri-containerd.apparmor.d`) in k3s security profile; restricts signal reception to known peers (host and containerd manager) for a tighter security posture
+
 ## [1.3.11] - 2026-03-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Reverted unrestricted `signal,` AppArmor rule back to targeted peer-specific rules (`signal (receive) peer=unconfined` and `signal (receive) peer=cri-containerd.apparmor.d`) in k3s security profile; restricts signal reception to known peers (host and containerd manager) for a tighter security posture
+- Reverted unrestricted `signal,` AppArmor rule back to targeted peer-specific rules in k3s security profile; restricts signal operations to known peers (host and containerd manager) for a tighter security posture while maintaining full functionality
+- Added `signal (send) peer=cri-containerd.apparmor.d` rule to allow container processes to signal each other (e.g. PID 1 sending SIGTERM to children during graceful shutdown)
 
 ## [1.3.11] - 2026-03-31
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: container
-version: 1.3.11
+version: 1.3.12
 readme: README.md
 
 authors:

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -149,6 +149,8 @@
                   signal (receive) peer=unconfined,
                   # Manager may send signals to container processes.
                   signal (receive) peer=cri-containerd.apparmor.d,
+                  # Allow container processes to signal each other (e.g. PID 1 → children).
+                  signal (send) peer=cri-containerd.apparmor.d,
 
                   deny @{PROC}/* w,
                   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -145,9 +145,10 @@
                   file,
                   umount,
 
-                  # Allow all signal operations (send/receive) — required for runc to
-                  # signal container init processes (SIGTERM/SIGKILL) during pod termination.
-                  signal,
+                  # Host (privileged) processes may send signals to container processes.
+                  signal (receive) peer=unconfined,
+                  # Manager may send signals to container processes.
+                  signal (receive) peer=cri-containerd.apparmor.d,
 
                   deny @{PROC}/* w,
                   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,


### PR DESCRIPTION
## Summary

- Reverted unrestricted `signal,` AppArmor rule back to targeted peer-specific rules (`signal (receive) peer=unconfined` and `signal (receive) peer=cri-containerd.apparmor.d`)
- Tighter security posture: only allows signal reception from known peers (host and containerd manager)
- Bumped version to 1.3.12 and updated CHANGELOG.md

## Test plan

- [ ] Deploy k3s with AppArmor enabled on Ubuntu 24.04
- [ ] Verify pod termination works correctly (`kubectl delete pod`)
- [ ] Verify no AppArmor denials in `dmesg` related to signal operations