### PR TITLE
feat(k3s): add toggle to disable cri-containerd AppArmor profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.13] - 2026-05-03
+
+### Added
+
+- New `k3s_cri_apparmor_profile_enabled` variable (default `true`,
+  backwards-compatible) to opt out of deploying the `cri-containerd.apparmor.d`
+  profile in the k3s role; when set to `false` the role unloads the profile
+  from the kernel, removes the file, and notifies `Restart k3s`. Workaround
+  for kernel 6.17 AppArmor profile-stacking bugs
+  ([k3s-io/k3s#13625](https://github.com/k3s-io/k3s/issues/13625),
+  [containerd/containerd#12886](https://github.com/containerd/containerd/issues/12886))
+  which cause pod termination to hang and flood dmesg with SIGURG denials
+
 ## [1.3.12] - 2026-04-01
 
 ### Changed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: container
-version: 1.3.12
+version: 1.3.13
 readme: README.md
 
 authors:

--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -107,6 +107,10 @@ k3s_selinux_custom_policy: false
 # AppArmor profile disabled by default - K3s requires many system operations
 # (mount, file_lock, proc access) that are difficult to whitelist correctly
 k3s_apparmor_profile: false
+# Deploy and load the cri-containerd AppArmor profile for container workloads.
+# Set to false to skip deployment AND remove any previously deployed profile
+# (e.g. as workaround for kernel 6.17 profile-stacking bugs).
+k3s_cri_apparmor_profile_enabled: true
 k3s_debug_security: false
 
 # K3s private registry configuration

--- a/roles/k3s/meta/argument_specs.yml
+++ b/roles/k3s/meta/argument_specs.yml
@@ -272,6 +272,14 @@ argument_specs:
                 default: false
                 description: "Apply AppArmor profile for K3s"
 
+            k3s_cri_apparmor_profile_enabled:
+                type: "bool"
+                default: true
+                description: >-
+                    Deploy and load the cri-containerd AppArmor profile.
+                    When false, any existing profile is unloaded and removed
+                    (e.g. workaround for kernel 6.17 profile-stacking bugs).
+
             k3s_debug_security:
                 type: "bool"
                 default: false

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -183,14 +183,47 @@
             mode: "0644"
         become: true
         register: cri_containerd_profile_updated
+        when: k3s_cri_apparmor_profile_enabled | default(true) | bool
 
       - name: Reload cri-containerd AppArmor profile
         ansible.builtin.shell: >
             apparmor_parser -r /etc/apparmor.d/cri-containerd.apparmor.d ||
             apparmor_parser /etc/apparmor.d/cri-containerd.apparmor.d
         become: true
-        when: cri_containerd_profile_updated is changed
+        when:
+            - k3s_cri_apparmor_profile_enabled | default(true) | bool
+            - cri_containerd_profile_updated is changed
         changed_when: true
+
+      # Disable path: remove any previously deployed cri-containerd profile.
+      # Workaround for kernel 6.17 profile-stacking signal-rule bug
+      # (k3s-io/k3s#13625, containerd/containerd#12886) that breaks pod
+      # termination and floods dmesg with SIGURG denials.
+      - name: Stat existing cri-containerd AppArmor profile
+        ansible.builtin.stat:
+            path: /etc/apparmor.d/cri-containerd.apparmor.d
+        register: cri_containerd_profile_file
+        when: not (k3s_cri_apparmor_profile_enabled | default(true) | bool)
+
+      - name: Unload cri-containerd AppArmor profile from kernel
+        ansible.builtin.command:
+            cmd: apparmor_parser -R /etc/apparmor.d/cri-containerd.apparmor.d
+        become: true
+        when:
+            - not (k3s_cri_apparmor_profile_enabled | default(true) | bool)
+            - cri_containerd_profile_file.stat.exists | default(false)
+        register: cri_containerd_profile_unloaded
+        changed_when: cri_containerd_profile_unloaded.rc == 0
+        failed_when: false
+        notify: Restart k3s
+
+      - name: Remove cri-containerd AppArmor profile file
+        ansible.builtin.file:
+            path: /etc/apparmor.d/cri-containerd.apparmor.d
+            state: absent
+        become: true
+        when: not (k3s_cri_apparmor_profile_enabled | default(true) | bool)
+        notify: Restart k3s
 
       - name: Create AppArmor profile for K3s
         ansible.builtin.copy:

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -222,7 +222,9 @@
             path: /etc/apparmor.d/cri-containerd.apparmor.d
             state: absent
         become: true
-        when: not (k3s_cri_apparmor_profile_enabled | default(true) | bool)
+        when:
+            - not (k3s_cri_apparmor_profile_enabled | default(true) | bool)
+            - cri_containerd_profile_file.stat.exists | default(false)
         notify: Restart k3s
 
       - name: Create AppArmor profile for K3s


### PR DESCRIPTION
## Summary

- Adds `k3s_cri_apparmor_profile_enabled` (default `true`, backwards-compatible) to opt out of deploying the `cri-containerd.apparmor.d` profile.
- When set to `false`, the role skips deployment, unloads any previously loaded profile from the kernel via `apparmor_parser -R`, removes the file, and notifies `Restart k3s`.
- Workaround for kernel 6.17 AppArmor profile-stacking bugs ([k3s-io/k3s#13625](https://github.com/k3s-io/k3s/issues/13625), [containerd/containerd#12886](https://github.com/containerd/containerd/issues/12886)) that cause pod termination to hang and flood dmesg with SIGURG denials.
- Bumps collection to 1.3.13 and updates CHANGELOG.

## Test plan

- [ ] Apply role with `k3s_cri_apparmor_profile_enabled: true` (default) on a fresh host — profile is deployed and loaded.
- [ ] Apply role with `k3s_cri_apparmor_profile_enabled: false` on a host where the profile was previously deployed — profile is unloaded, file removed, k3s restarted.
- [ ] Apply role with `k3s_cri_apparmor_profile_enabled: false` on a host without the profile — idempotent, no errors.
- [ ] Verify `argument_specs.yml` validation passes.