### PR TITLE
feat(k3s): support etcd-s3 credentials in server config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `k3s_etcd_s3_access_key` / `k3s_etcd_s3_secret_key` variables in the k3s
+  role: render `etcd-s3-access-key` / `etcd-s3-secret-key` into the server
+  config so scheduled etcd snapshots can authenticate against S3-compatible
+  storage (e.g. Cloudflare R2). The config file is deployed with mode `0600`,
+  so credentials stay root-only on disk. Both variables are optional and
+  omitted when unset — existing consumers are unaffected.
+
 ## [1.3.13] - 2026-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so credentials stay root-only on disk. Both variables are optional and
   omitted when unset — existing consumers are unaffected.
 
+### Changed
+
+- Documented the full etcd snapshot variable family in the k3s role's
+  `argument_specs.yml` (`k3s_etcd_expose_metrics`,
+  `k3s_etcd_snapshot_schedule_cron`, `k3s_etcd_snapshot_retention`,
+  `k3s_etcd_snapshot_dir`, `k3s_etcd_s3`, `k3s_etcd_s3_endpoint`,
+  `k3s_etcd_s3_region`, `k3s_etcd_s3_bucket`, `k3s_etcd_s3_folder` plus the two
+  new credential variables). These were previously template-only and
+  undocumented. All are `required: false` and carry no spec default — the
+  template gates each with `is defined`, so a default would change behaviour —
+  and the two credential keys are marked `no_log: true`.
+
 ## [1.3.13] - 2026-05-03
 
 ### Added

--- a/roles/k3s/meta/argument_specs.yml
+++ b/roles/k3s/meta/argument_specs.yml
@@ -165,6 +165,96 @@ argument_specs:
                 default: 110
                 description: "Maximum number of pods per node"
 
+            # etcd snapshot configuration. All variables are optional and
+            # intentionally carry no spec default: the server-config template
+            # gates each one with `is defined`, so a default here would make
+            # the key render unconditionally and change behaviour. Leave them
+            # undefined to omit the corresponding etcd flag.
+            k3s_etcd_expose_metrics:
+                type: "bool"
+                required: false
+                description: >-
+                    Expose etcd metrics (`etcd-expose-metrics`). Omitted when
+                    undefined.
+
+            k3s_etcd_snapshot_schedule_cron:
+                type: "str"
+                required: false
+                description: >-
+                    Cron schedule for automatic etcd snapshots
+                    (`etcd-snapshot-schedule-cron`, e.g. `0 */6 * * *`).
+                    Omitted when undefined.
+
+            k3s_etcd_snapshot_retention:
+                type: "int"
+                required: false
+                description: >-
+                    Number of etcd snapshots to retain
+                    (`etcd-snapshot-retention`). Applies to both local and S3
+                    snapshots. Omitted when undefined.
+
+            k3s_etcd_snapshot_dir:
+                type: "str"
+                required: false
+                description: >-
+                    Directory for local etcd snapshots (`etcd-snapshot-dir`).
+                    Omitted when undefined (K3s default location).
+
+            k3s_etcd_s3:
+                type: "bool"
+                required: false
+                description: >-
+                    Enable uploading etcd snapshots to an S3-compatible store
+                    (`etcd-s3`). Passed through `| bool`, so a string value
+                    such as "False" is treated correctly. Omitted when
+                    undefined.
+
+            k3s_etcd_s3_endpoint:
+                type: "str"
+                required: false
+                description: >-
+                    S3 endpoint host for etcd snapshot uploads
+                    (`etcd-s3-endpoint`), without scheme. Omitted when
+                    undefined.
+
+            k3s_etcd_s3_region:
+                type: "str"
+                required: false
+                description: >-
+                    S3 region for etcd snapshot uploads (`etcd-s3-region`,
+                    e.g. `auto` for Cloudflare R2). Omitted when undefined.
+
+            k3s_etcd_s3_bucket:
+                type: "str"
+                required: false
+                description: >-
+                    S3 bucket for etcd snapshot uploads (`etcd-s3-bucket`).
+                    Omitted when undefined.
+
+            k3s_etcd_s3_folder:
+                type: "str"
+                required: false
+                description: >-
+                    Folder/prefix within the S3 bucket for etcd snapshots
+                    (`etcd-s3-folder`). Omitted when undefined.
+
+            k3s_etcd_s3_access_key:
+                type: "str"
+                required: false
+                no_log: true
+                description: >-
+                    Access key for the S3-compatible etcd snapshot store
+                    (`etcd-s3-access-key`). Rendered into the server config
+                    (mode 0600). Omitted when undefined.
+
+            k3s_etcd_s3_secret_key:
+                type: "str"
+                required: false
+                no_log: true
+                description: >-
+                    Secret key for the S3-compatible etcd snapshot store
+                    (`etcd-s3-secret-key`). Rendered into the server config
+                    (mode 0600). Omitted when undefined.
 
             k3s_extra_server_args:
                 type: "list"

--- a/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
+++ b/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
@@ -123,6 +123,14 @@
 {%-   set _ = k3s_config.update({'etcd-s3-folder': k3s_etcd_s3_folder}) -%}
 {%- endif -%}
 
+{%- if k3s_etcd_s3_access_key is defined and k3s_etcd_s3_access_key -%}
+{%-   set _ = k3s_config.update({'etcd-s3-access-key': k3s_etcd_s3_access_key}) -%}
+{%- endif -%}
+
+{%- if k3s_etcd_s3_secret_key is defined and k3s_etcd_s3_secret_key -%}
+{%-   set _ = k3s_config.update({'etcd-s3-secret-key': k3s_etcd_s3_secret_key}) -%}
+{%- endif -%}
+
 {#- === NODE CONFIGURATION === -#}
 {%- if k3s_node_name is defined and k3s_node_name -%}
 {%-   set _ = k3s_config.update({'node-name': k3s_node_name}) -%}

--- a/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
+++ b/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
@@ -103,7 +103,10 @@
 {%- endif -%}
 
 {#- S3 Backup Integration -#}
-{%- if k3s_etcd_s3 is defined and k3s_etcd_s3 -%}
+{#- `| bool` guards against string-typed truthiness: consumers commonly set
+    this via a Jinja expression (e.g. env-lookup gate), and without native
+    templating that yields the string "False" — which is truthy. -#}
+{%- if k3s_etcd_s3 is defined and k3s_etcd_s3 | bool -%}
 {%-   set _ = k3s_config.update({'etcd-s3': true}) -%}
 {%- endif -%}
 


### PR DESCRIPTION
## Summary

Das Server-Config-Template rendert bereits `etcd-s3-endpoint/region/bucket/folder`, bot aber keinen Weg, die S3-Credentials zu setzen. Neu: optionale `k3s_etcd_s3_access_key` / `k3s_etcd_s3_secret_key`, die als `etcd-s3-access-key` / `etcd-s3-secret-key` in die Config gerendert werden.

- Config-File wird von der Rolle mit Mode `0600` deployed — Credentials bleiben root-only.
- Beide Variablen optional, werden bei unset weggelassen — bestehende Consumer unverändert.
- Konsistent mit dem bestehenden Pattern (alle etcd-s3-Vars sind `is defined`-gated, keine defaults, keine argument_specs-Einträge — wie die übrigen etcd-s3-Vars).

## Kontext

Gebraucht von sbaerlocher/infrastructure: K3s-etcd-Snapshots (nuvulus, single server) sollen nach Cloudflare R2 hochgeladen werden. Konzept: sbaerlocher/infrastructure#207.

## Test plan

- [ ] CI (lint, molecule)
- [ ] Konsument-Test folgt im infrastructure-Repo nach Release