### PR TITLE
feat(k3s): parametrise the server API readiness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   storage (e.g. Cloudflare R2). The config file is deployed with mode `0600`,
   so credentials stay root-only on disk. Both variables are optional and
   omitted when unset — existing consumers are unaffected.
+- New `k3s_health_check_delay` / `k3s_health_check_timeout` /
+  `k3s_health_check_sleep` variables (defaults `30` / `600` / `10`,
+  backwards-compatible) parametrise the server API readiness probe in the
+  k3s role. The `wait_for` task previously hard-coded `delay: 30`, an
+  unconditional pre-sleep on every run; consumers running against an
+  already-converged server can now set `k3s_health_check_delay: 0` to skip
+  the idle wait while `timeout`/`sleep` still cover the cold-bootstrap race.
 
 ### Changed
 

--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -3,7 +3,7 @@
 
 # K3s version and installation
 # renovate: datasource=github-releases depName=k3s-io/k3s
-k3s_version: "v1.35.4+k3s1"
+k3s_version: "v1.36.1+k3s1"
 k3s_channel: "stable"
 k3s_binary_checksum: ""
 

--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -33,11 +33,7 @@ k3s_node_ip: "{{ ansible_default_ipv4.address }}"
 k3s_bind_address: "{{ ansible_default_ipv4.address }}"
 k3s_https_listen_port: 6443
 
-# Readiness probe for the server API (wait_for on k3s_https_listen_port).
-# `delay` is an unconditional pre-sleep on every run; `timeout` already
-# covers the cold-bootstrap race, so consumers running against an
-# already-converged server can override k3s_health_check_delay: 0 to skip
-# the idle wait. Defaults preserve the historical behaviour.
+# Readiness probe tuning; set k3s_health_check_delay: 0 to skip idle wait on converged servers.
 k3s_health_check_delay: 30
 k3s_health_check_timeout: 600
 k3s_health_check_sleep: 10

--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -3,7 +3,7 @@
 
 # K3s version and installation
 # renovate: datasource=github-releases depName=k3s-io/k3s
-k3s_version: "v1.36.1+k3s1"
+k3s_version: "v1.35.4+k3s1"
 k3s_channel: "stable"
 k3s_binary_checksum: ""
 
@@ -32,6 +32,15 @@ k3s_tls_san: []
 k3s_node_ip: "{{ ansible_default_ipv4.address }}"
 k3s_bind_address: "{{ ansible_default_ipv4.address }}"
 k3s_https_listen_port: 6443
+
+# Readiness probe for the server API (wait_for on k3s_https_listen_port).
+# `delay` is an unconditional pre-sleep on every run; `timeout` already
+# covers the cold-bootstrap race, so consumers running against an
+# already-converged server can override k3s_health_check_delay: 0 to skip
+# the idle wait. Defaults preserve the historical behaviour.
+k3s_health_check_delay: 30
+k3s_health_check_timeout: 600
+k3s_health_check_sleep: 10
 
 # K3s data directory
 k3s_data_dir: "/var/lib/rancher/k3s"

--- a/roles/k3s/meta/argument_specs.yml
+++ b/roles/k3s/meta/argument_specs.yml
@@ -62,6 +62,28 @@ argument_specs:
                 default: 6443
                 description: "K3s HTTPS API server listen port"
 
+            k3s_health_check_delay:
+                type: "int"
+                required: false
+                default: 30
+                description: >-
+                    Pre-sleep before the server API readiness probe (wait_for).
+                    Set to 0 to skip the idle wait when running against an
+                    already-converged server; timeout/sleep still cover the
+                    cold-bootstrap race.
+
+            k3s_health_check_timeout:
+                type: "int"
+                required: false
+                default: 600
+                description: "Timeout for the server API readiness probe (wait_for)"
+
+            k3s_health_check_sleep:
+                type: "int"
+                required: false
+                default: 10
+                description: "Poll interval for the server API readiness probe (wait_for)"
+
             k3s_node_ip:
                 type: "str"
                 required: false

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -294,9 +294,9 @@
   ansible.builtin.wait_for:
       port: "{{ k3s_https_listen_port }}"
       host: "{{ k3s_health_check_host }}"
-      delay: 30
-      timeout: 600
-      sleep: 10
+      delay: "{{ k3s_health_check_delay }}"
+      timeout: "{{ k3s_health_check_timeout }}"
+      sleep: "{{ k3s_health_check_sleep }}"
   when: k3s_role == "server"
 
 # - name: Set kubeconfig permissions


### PR DESCRIPTION
## Summary

Die `wait_for`-Task, die auf die K3s-Server-API pollt, hatte `delay: 30` hartkodiert — ein unbedingter Vorab-Sleep bei jedem Lauf. Auf einem konvergenten Server (Normalfall beim Samstags-Re-Run) ist die API längst auf 6443 erreichbar; `timeout`/`sleep` decken den Cold-Bootstrap-Race ohnehin ab.

Neu: `k3s_health_check_delay` / `_timeout` / `_sleep` (Defaults `30` / `600` / `10` → verhaltensneutral, solange nicht überschrieben). Consumer gegen einen konvergenten Server setzen `k3s_health_check_delay: 0` und sparen ~30s auf dem kritischen Pfad. `argument_specs` dokumentiert alle drei.

## Kontext

Das ist die rollenseitige Parametrisierung, die `sbaerlocher/infrastructure` (PR #194) bereits durch `k3s_health_check_delay: 0` vorweggenommen hat — dort ein harmloser No-op, bis dieser PR gemerged und der Galaxy-Tag nachgezogen ist.

## Test plan

- [ ] CI (lint, molecule) — molecule rendert die Server-Config und sollte mit Default-Delay konvergieren