### PR TITLE
fix(ci): grant security-events write in merge.yml

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,6 +14,8 @@ concurrency:
 
 permissions:
     contents: read
+    security-events: write
+    actions: read
 
 jobs:
     ci:
@@ -26,6 +28,3 @@ jobs:
 
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-06-02
-        permissions:
-            contents: read
-            actions: read


### PR DESCRIPTION
## Summary

- The `Merge to Main` workflow (`merge.yml`) failed on push to main with a `startup_failure`: the caller granted only `contents: read`, but the `ci-ansible-collection` reusable's nested `security-scan` job (Trivy SARIF upload) requires `security-events: write`.
- Declare the full permission superset at workflow level (`contents: read`, `security-events: write`, `actions: read`), matching `pull-request.yml`, and drop the now-redundant per-job block on `security-secrets`.

## Test plan

- [ ] `Merge to Main` workflow no longer startup_failures (validates on this PR's merge to main)
- [ ] ci-ansible-collection jobs run green (lint, unit, sanity, build, security-scan)
- [ ] security-secrets job runs green