### PR TITLE
fix(ci): grant pull-requests read in merge and nightly-security

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -16,6 +16,7 @@ permissions:
     contents: read
     security-events: write
     actions: read
+    pull-requests: read
 
 jobs:
     ci:

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -15,6 +15,7 @@ concurrency:
 permissions:
     contents: read
     actions: read
+    pull-requests: read
 
 jobs:
     security-secrets:


### PR DESCRIPTION
## Summary

- `security-secrets.yml@2026-06-02` declares `pull-requests: read` at workflow level, but `merge.yml` and `nightly-security.yml` only granted `contents`/`actions`, causing a `startup_failure` on push to main and (would-be) on the weekly nightly schedule.
- Add `pull-requests: read` to both callers' permission superset.

This completes the permission-superset alignment for all reusables: `ci-ansible-collection` (security-events:write), `security-secrets` (actions:read + pull-requests:read), and `ai-claude-review` (already covered in pull-request.yml).

## Test plan

- [ ] `Merge to Main` workflow runs green on merge of this PR (no startup_failure)
- [ ] CI checks green (lint, unit, sanity, build, security-scan, secrets)