### PR TITLE
chore(release): 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-12
+
 ### Added
 
 - New `k3s_etcd_s3_access_key` / `k3s_etcd_s3_secret_key` variables in the k3s

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: container
-version: 1.3.13
+version: 1.4.0
 readme: README.md
 
 authors:


### PR DESCRIPTION
## Summary

Release-PR für **1.4.0**. Bündelt alle Änderungen seit 1.3.13:

| PR | Typ | Inhalt |
|----|-----|--------|
| #98 | feat | `k3s_etcd_s3_access_key` / `_secret_key` im Server-Config-Template — etcd-Snapshots können sich gegen S3-kompatible Stores (R2) authentifizieren |
| #98 | docs | Vollständige etcd-Snapshot-Var-Familie in `argument_specs.yml` (11 Vars, Secrets mit `no_log: true`) |
| #99 | feat | `k3s_health_check_delay/_timeout/_sleep` — parametrisierte Readiness-Probe (`delay: 0` spart ~30s auf konvergenten Servern) |
| #100 | fix | `docker_compose_v2`: kaputte `"{{ omit }}"`-Defaults entfernt (brach arg-spec-Validierung für Nicht-`str`-Typen unter Ansible 2.18+) |

**Minor-Bump:** zwei neue opt-in Feature-Variablen, vollständig rückwärtskompatibel.

## Was passiert beim Merge

`galaxy.yml` → `1.4.0`, CHANGELOG `[Unreleased]` → `[1.4.0] - 2026-06-12`. Der getaggte `1.4.0`-Push triggert `publish.yml` → Ansible Galaxy.

## Folge im Konsumenten-Repo

`sbaerlocher/infrastructure` pinnt `arillso.container >= 1.3.13` → zieht 1.4.0 automatisch. Damit greifen dort die etcd-s3-Credential-Vars (PR sbaerlocher/infrastructure#237) und der `k3s_health_check_delay: 0`-Override wird vom No-op zur echten Funktion.

## Test plan

- [ ] CI grün (lint, sanity, unit, build)
- [ ] Nach Merge: Tag `1.4.0` schneiden → publish.yml prüfen