### PR TITLE
ci: run per-role molecule scenarios on pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,6 +29,31 @@ jobs:
             python_version: "3.12"
             enable_unit_tests: true
 
+    molecule-docker:
+        # Roles keep molecule scenarios under roles/<role>/molecule/ rather
+        # than extensions/molecule/, so scenarios_root is set per role and
+        # the matrix is pinned to the single `default` scenario. The
+        # concurrency-suffix keeps each role's nested call out of the
+        # caller's concurrency group (see ansible.system pull-request.yml).
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-14
+        with:
+            collection_namespace: arillso
+            collection_name: container
+            python_version: "3.12"
+            scenarios_root: roles/docker/molecule
+            scenarios: '["default"]'
+            concurrency-suffix: molecule-docker
+
+    molecule-k3s:
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-14
+        with:
+            collection_namespace: arillso
+            collection_name: container
+            python_version: "3.12"
+            scenarios_root: roles/k3s/molecule
+            scenarios: '["default"]'
+            concurrency-suffix: molecule-k3s
+
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-06-14
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,12 +30,16 @@ jobs:
             enable_unit_tests: true
 
     molecule-docker:
-        # Roles keep molecule scenarios under roles/<role>/molecule/ rather
-        # than extensions/molecule/, so scenarios_root is set per role and
+        # docker (dockerd) and k3s (modprobe/cgroups) need a real kernel,
+        # so they run under the KVM (molecule-qemu) reusable rather than
+        # the docker driver. Roles keep molecule scenarios under
+        # roles/<role>/molecule/, so scenarios_root is set per role and
         # the matrix is pinned to the single `default` scenario. The
         # concurrency-suffix keeps each role's nested call out of the
-        # caller's concurrency group (see ansible.system pull-request.yml).
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-14
+        # caller's concurrency group.
+        # NOTE: branch ref while the KVM reusable PoC is validated; pin to
+        # a date tag once arillso/.github merges it.
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule-kvm.yml@feat/ci-ansible-molecule-kvm
         with:
             collection_namespace: arillso
             collection_name: container
@@ -45,7 +49,7 @@ jobs:
             concurrency-suffix: molecule-docker
 
     molecule-k3s:
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-14
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule-kvm.yml@feat/ci-ansible-molecule-kvm
         with:
             collection_namespace: arillso
             collection_name: container

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,9 +37,7 @@ jobs:
         # the matrix is pinned to the single `default` scenario. The
         # concurrency-suffix keeps each role's nested call out of the
         # caller's concurrency group.
-        # NOTE: branch ref while the KVM reusable PoC is validated; pin to
-        # a date tag once arillso/.github merges it.
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule-kvm.yml@feat/ci-ansible-molecule-kvm
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule-kvm.yml@2026-06-17
         with:
             collection_namespace: arillso
             collection_name: container
@@ -49,7 +47,7 @@ jobs:
             concurrency-suffix: molecule-docker
 
     molecule-k3s:
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule-kvm.yml@feat/ci-ansible-molecule-kvm
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule-kvm.yml@2026-06-17
         with:
             collection_namespace: arillso
             collection_name: container

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,26 +31,28 @@ jobs:
 
     molecule-docker:
         # docker (dockerd) and k3s (modprobe/cgroups) need a real kernel,
-        # so they run under the KVM (molecule-qemu) reusable rather than
-        # the docker driver. Roles keep molecule scenarios under
+        # so they run with the qemu (KVM) molecule driver rather than the
+        # docker driver. Roles keep molecule scenarios under
         # roles/<role>/molecule/, so scenarios_root is set per role and
         # the matrix is pinned to the single `default` scenario. The
         # concurrency-suffix keeps each role's nested call out of the
         # caller's concurrency group.
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule-kvm.yml@2026-06-17
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-18
         with:
             collection_namespace: arillso
             collection_name: container
+            driver: qemu
             python_version: "3.12"
             scenarios_root: roles/docker/molecule
             scenarios: '["default"]'
             concurrency-suffix: molecule-docker
 
     molecule-k3s:
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule-kvm.yml@2026-06-17
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-18
         with:
             collection_namespace: arillso
             collection_name: container
+            driver: qemu
             python_version: "3.12"
             scenarios_root: roles/k3s/molecule
             scenarios: '["default"]'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,10 @@ This is an Ansible collection that provides roles for container and orchestratio
 ```text
 ansible.container/
 ├── .github/workflows/
-│   ├── ci.yml              # All-in-one: linting, tests, build
-│   └── publish.yml         # Galaxy publishing
+│   ├── pull-request.yml    # Lint, tests, per-role molecule, secret scan, Claude review
+│   ├── merge.yml           # CI + secret scan on push to main
+│   ├── nightly-security.yml # Scheduled weekly secret scan
+│   └── tag.yml             # Galaxy publishing (triggered by tag)
 ├── roles/
 │   ├── docker/
 │   ├── docker_compose/
@@ -84,12 +86,13 @@ Three-level testing strategy:
 2. **Molecule Tests** - For individual roles
     - Location: `roles/*/molecule/default/`
     - Run: `molecule test -s default`
+    - CI: one `molecule-<role>` job per role in `pull-request.yml` (docker, k3s)
 
 3. **Integration Tests** (ansible-test) - For role integration
     - Location: `tests/integration/targets/`
     - Run: `ansible-test integration`
 
-All tests consolidated in single `ci.yml` workflow.
+Tests run via the reusable CI (`arillso/.github`) on pull requests and merges.
 
 ### Documentation
 
@@ -119,10 +122,12 @@ k3s_version: "v1.35.2+k3s1"
 
 ### CI/CD
 
-**Standard workflows:**
+Event-focused workflows calling reusables from `arillso/.github`:
 
-- `ci.yml` - All linting, tests (unit, molecule, integration), and build
-- `publish.yml` - Galaxy publishing (triggered by tag)
+- `pull-request.yml` - Lint, unit/integration tests, per-role molecule, secret scan, and Claude review on PRs
+- `merge.yml` - Same CI plus secret scan on push to `main`
+- `nightly-security.yml` - Scheduled weekly secret scan
+- `tag.yml` - Publishes to Ansible Galaxy on tag push (e.g. `0.0.8`)
 
 ### Release Process
 
@@ -141,7 +146,7 @@ k3s_version: "v1.35.2+k3s1"
     - Command: `git tag 0.0.8 && git push origin 0.0.8`
 
 4. **Automated workflow triggers**
-    - `publish.yml` publishes to Ansible Galaxy
+    - `tag.yml` publishes to Ansible Galaxy
     - Creates GitHub Release with CHANGELOG notes
 
 ## Do
@@ -161,6 +166,6 @@ k3s_version: "v1.35.2+k3s1"
 - ❌ Do not use deprecated Ansible syntax
 - ❌ Do not hardcode values that should be variables
 - ❌ Do not add excessive comments to defaults/main.yml
-- ❌ Do not create separate test workflows (use ci.yml)
+- ❌ Do not create separate test workflows (CI runs via the reusable in `pull-request.yml`/`merge.yml`)
 - ❌ Do not skip CHANGELOG.md updates before releases
 - ❌ Do not use 'v' prefix in Ansible Collection tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **docker role**: the Docker prune service/timer setup called
+  `arillso.system.systemd_unit`, a role that no longer exists in
+  `arillso.system` (replaced by the `systemd` role with a `systemd_units`
+  list interface), so the role failed with "role
+  'arillso.system.systemd_unit' was not found". Rewrite the prune units in
+  the `systemd_units` format and call `arillso.system.systemd`.
+
+### Changed
+
+- **Dependency**: raise the `arillso.system` lower bound from `>=0.0.17` to
+  `>=1.0.0` — the `systemd` role with the `systemd_units` interface the docker
+  role now uses is only available from 1.0.0 onwards.
+
 ## [1.4.0] - 2026-06-12
 
 ### Added

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,7 +20,7 @@ tags:
     - linux
 
 dependencies:
-    arillso.system: ">=0.0.17"
+    arillso.system: ">=1.0.0"
     community.docker: ">=3.4.11"
 
 repository: https://github.com/arillso/ansible.container

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ black>=26.5.1
 # Testing
 molecule>=26.4.0
 molecule-plugins[docker]>=25.8.12
+molecule-qemu>=0.4.7
 pytest>=9.1.0
 pytest-ansible>=26.4.0
 pytest-cov>=7.1.0

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -6,37 +6,41 @@ docker_daemon:
     log-driver: journald
     live-restore: true
 
+# Consumed by the arillso.system.systemd role (systemd_units interface):
+# each entry is {name: <full unit filename>, unit: {Section: {Key: Value}}}.
 docker_systemd_units:
-    - name: docker-prune
-      type: service
-      systemd_unit_generic_options:
-          - "Description=Docker Image Prune Service"
-      systemd_unit_options:
-          - "Type=oneshot"
-          - "ExecStart=/usr/bin/docker system prune -af --filter 'until=1h'"
+    - name: docker-prune.service
+      unit:
+          Unit:
+              Description: Docker Image Prune Service
+          Service:
+              Type: oneshot
+              ExecStart: "/usr/bin/docker system prune -af --filter 'until=1h'"
 
-    - name: docker-prune
-      type: timer
-      systemd_unit_generic_options:
-          - "Description=Run docker image prune regularly"
-      systemd_unit_options:
-          - "OnCalendar=*:0/5"
-          - "Persistent=true"
+    - name: docker-prune.timer
+      unit:
+          Unit:
+              Description: Run docker image prune regularly
+          Timer:
+              OnCalendar: "*:0/5"
+              Persistent: true
+          Install:
+              WantedBy: timers.target
 
-    - name: docker-prune-volumes
-      type: service
-      systemd_unit_generic_options:
-          - "Description=Docker Image Prune Service"
-      systemd_unit_options:
-          - "Type=oneshot"
-          - "ExecStart=/usr/bin/docker system prune -af --volumes"
+    - name: docker-prune-volumes.service
+      unit:
+          Unit:
+              Description: Docker Volume Prune Service
+          Service:
+              Type: oneshot
+              ExecStart: "/usr/bin/docker system prune -af --volumes"
 
-    - name: docker-prune-volumes
-      type: timer
-      systemd_unit_generic_options:
-          - "Description=Run docker image prune volumes regularly"
-      systemd_unit_options:
-          - "OnCalendar=weekly"
-          - "Persistent=true"
-      systemd_unit_install_options:
-          - "WantedBy=timers.target"
+    - name: docker-prune-volumes.timer
+      unit:
+          Unit:
+              Description: Run docker image prune volumes regularly
+          Timer:
+              OnCalendar: weekly
+              Persistent: true
+          Install:
+              WantedBy: timers.target

--- a/roles/docker/meta/argument_specs.yml
+++ b/roles/docker/meta/argument_specs.yml
@@ -266,23 +266,16 @@ argument_specs:
             docker_systemd_units:
                 type: list
                 elements: dict
-                description: List of systemd units to create for Docker pruning tasks.
+                description: >-
+                    Systemd units to create for Docker pruning, in the
+                    arillso.system.systemd `systemd_units` format.
                 options:
                     name:
                         type: str
-                        description: The name of the systemd unit.
-                    type:
-                        type: str
-                        description: The type of the systemd unit, e.g., service or timer.
-                    systemd_unit_generic_options:
-                        type: list
-                        elements: str
-                        description: Generic systemd options for the unit.
-                    systemd_unit_options:
-                        type: list
-                        elements: str
-                        description: Specific options for the systemd service or timer.
-                    systemd_unit_install_options:
-                        type: list
-                        elements: str
-                        description: Install options for the systemd unit.
+                        required: true
+                        description: Full unit filename, including the .service/.timer suffix.
+                    unit:
+                        type: dict
+                        description: >-
+                            Structured unit definition as {Section: {Key: Value}};
+                            rendered to an INI unit file by the systemd role.

--- a/roles/docker/molecule/default/converge.yml
+++ b/roles/docker/molecule/default/converge.yml
@@ -8,7 +8,7 @@
       # `docker-ce=28.5.2` never matches apt's full version string
       # (e.g. 5:28.5.2-1~debian.12~bookworm), so CI must not pin.
       docker_version: ""
-      docker_daemon_config:
+      docker_daemon:
           log-driver: json-file
           log-opts:
               max-size: "10m"

--- a/roles/docker/molecule/default/converge.yml
+++ b/roles/docker/molecule/default/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   become: true
   vars:
+      # Install whatever docker-ce the upstream repo currently offers.
+      # The default pins an exact patch version, but the bare
+      # `docker-ce=28.5.2` never matches apt's full version string
+      # (e.g. 5:28.5.2-1~debian.12~bookworm), so CI must not pin.
+      docker_version: ""
       docker_daemon_config:
           log-driver: json-file
           log-opts:

--- a/roles/docker/molecule/default/converge.yml
+++ b/roles/docker/molecule/default/converge.yml
@@ -10,9 +10,6 @@
       docker_version: ""
       docker_daemon:
           log-driver: json-file
-          log-opts:
-              max-size: "10m"
-              max-file: "3"
           storage-driver: overlay2
           features:
               buildkit: true

--- a/roles/docker/molecule/default/molecule.yml
+++ b/roles/docker/molecule/default/molecule.yml
@@ -5,26 +5,18 @@ dependency:
         requirements-file: requirements.yml
 
 driver:
-    name: docker
+    name: molecule-qemu
 
 platforms:
     - name: docker-ubuntu-22.04
-      image: geerlingguy/docker-ubuntu2204-ansible:latest
-      ansible.builtin.command: ""
-      volumes:
-          - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      cgroupns_mode: host
-      privileged: true
-      pre_build_image: true
-
-    - name: docker-debian-12
-      image: geerlingguy/docker-debian12-ansible:latest
-      ansible.builtin.command: ""
-      volumes:
-          - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      cgroupns_mode: host
-      privileged: true
-      pre_build_image: true
+      image_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+      image_checksum: sha256:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2222
+      network_ssh_user: ubuntu
+      vm_cpus: 2
+      vm_memory: 2048
 
 provisioner:
     name: ansible
@@ -33,6 +25,10 @@ provisioner:
             callbacks_enabled: profile_tasks, timer
             stdout_callback: ansible.builtin.default
             result_format: yaml
+    inventory:
+        host_vars:
+            docker-ubuntu-22.04:
+                ansible_become: true
     playbooks:
         converge: converge.yml
         verify: verify.yml

--- a/roles/docker/molecule/default/molecule.yml
+++ b/roles/docker/molecule/default/molecule.yml
@@ -30,8 +30,9 @@ provisioner:
     name: ansible
     config_options:
         defaults:
-            callbacks_enabled: profile_tasks, timer, yaml
-            stdout_callback: yaml
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
+            result_format: yaml
     playbooks:
         converge: converge.yml
         verify: verify.yml

--- a/roles/docker/molecule/default/requirements.yml
+++ b/roles/docker/molecule/default/requirements.yml
@@ -3,4 +3,4 @@ collections:
     - name: community.docker
       version: ">=3.4.11"
     - name: arillso.system
-      version: ">=0.0.17"
+      version: ">=1.0.0"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -65,16 +65,15 @@
   notify:
       - Restart docker
 
-- name: Create Docker Prune Service and Timer File
+- name: Create Docker Prune Service and Timer Files
   ansible.builtin.include_role:
-      name: arillso.system.systemd_unit
+      name: arillso.system.systemd
   vars:
-      systemd_unit_name: "{{ item.name }}"
-      systemd_unit_type: "{{ item.type }}"
-      systemd_unit_generic_options: "{{ item.systemd_unit_generic_options | default('') }}"
-      systemd_unit_options: "{{ item.systemd_unit_options | default('') }}"
-      systemd_unit_install_options: "{{ item.systemd_unit_install_options | default('') }}"
-  loop: "{{ docker_systemd_units }}"
+      # Only the unit-file entry point; service/journald management stays
+      # off so this call just writes the prune unit files.
+      systemd_service_enabled: false
+      systemd_journald_enabled: false
+      systemd_units: "{{ docker_systemd_units }}"
 
 - name: Enable and start systemd timers for Docker
   become: true
@@ -83,7 +82,7 @@
       enabled: true
       daemon_reload: true
   loop: "{{ docker_systemd_units }}"
-  when: item.type == 'timer'
+  when: item.name is search('\.timer$')
 
 - name: Run handlers
   ansible.builtin.meta: flush_handlers

--- a/roles/k3s/molecule/default/converge.yml
+++ b/roles/k3s/molecule/default/converge.yml
@@ -9,6 +9,16 @@
           - traefik
           - servicelb
       k3s_write_kubeconfig_mode: "0644"
+  pre_tasks:
+      # The k3s install script needs curl, which the base test images
+      # do not ship. Install it before the role runs.
+      - name: Ensure curl is present
+        ansible.builtin.apt:
+            name: curl
+            state: present
+            update_cache: true
+        when: ansible_os_family == "Debian"
+
   tasks:
       - name: Include k3s role
         ansible.builtin.include_role:

--- a/roles/k3s/molecule/default/molecule.yml
+++ b/roles/k3s/molecule/default/molecule.yml
@@ -5,18 +5,18 @@ dependency:
         requirements-file: requirements.yml
 
 driver:
-    name: docker
+    name: molecule-qemu
 
 platforms:
     - name: k3s-ubuntu-22.04
-      image: geerlingguy/docker-ubuntu2204-ansible:latest
-      ansible.builtin.command: ""
-      volumes:
-          - /sys/fs/cgroup:/sys/fs/cgroup:rw
-          - /var/lib/rancher:/var/lib/rancher
-      cgroupns_mode: host
-      privileged: true
-      pre_build_image: true
+      image_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+      image_checksum: sha256:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2222
+      network_ssh_user: ubuntu
+      vm_cpus: 2
+      vm_memory: 3072
 
 provisioner:
     name: ansible
@@ -25,6 +25,10 @@ provisioner:
             callbacks_enabled: profile_tasks, timer
             stdout_callback: ansible.builtin.default
             result_format: yaml
+    inventory:
+        host_vars:
+            k3s-ubuntu-22.04:
+                ansible_become: true
     playbooks:
         converge: converge.yml
         verify: verify.yml

--- a/roles/k3s/molecule/default/molecule.yml
+++ b/roles/k3s/molecule/default/molecule.yml
@@ -22,8 +22,9 @@ provisioner:
     name: ansible
     config_options:
         defaults:
-            callbacks_enabled: profile_tasks, timer, yaml
-            stdout_callback: yaml
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
+            result_format: yaml
     playbooks:
         converge: converge.yml
         verify: verify.yml

--- a/roles/k3s/molecule/default/requirements.yml
+++ b/roles/k3s/molecule/default/requirements.yml
@@ -3,4 +3,4 @@ collections:
     - name: kubernetes.core
       version: ">=2.4.0"
     - name: arillso.system
-      version: ">=0.0.17"
+      version: ">=1.0.0"


### PR DESCRIPTION
## Summary

Wires the role-level molecule scenarios into CI for `ansible.container`. The `docker` and `k3s` roles ship `roles/<role>/molecule/default/`, but no workflow was running them on PRs.

## Changes

- **`pull-request.yml`**: add `molecule-docker` and `molecule-k3s` jobs calling the `ci-ansible-molecule.yml` reusable. Because the scenarios live under `roles/<role>/molecule/` (not the reusable's default `extensions/molecule/`), each job sets `scenarios_root` per role, pins `scenarios: '["default"]'`, and uses a `concurrency-suffix` to avoid the caller's concurrency group (same pattern as `ansible.system`).
- **`AGENTS.md`**: was still documenting the retired `ci.yml`/`publish.yml` layout — updated to the event-focused workflows.

## Notes

Only `docker` and `k3s` carry molecule scenarios; the other roles (docker_compose_v2, docker_login, fleet, helm, tailscale) have none, so no job is added for them.