### PR TITLE
test(molecule): add Debian 12 coverage and fix docker_daemon log-opts spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   list interface), so the role failed with "role
   'arillso.system.systemd_unit' was not found". Rewrite the prune units in
   the `systemd_units` format and call `arillso.system.systemd`.
+- **docker role**: add the missing `log-opts` option to the `docker_daemon`
+  argument spec. `log-opts` is a valid `daemon.json` key but was absent from
+  the spec, so passing it (e.g. log rotation `max-size`/`max-file`) failed
+  argument validation.
 
 ### Changed
 
 - **Dependency**: raise the `arillso.system` lower bound from `>=0.0.17` to
   `>=1.0.0` — the `systemd` role with the `systemd_units` interface the docker
   role now uses is only available from 1.0.0 onwards.
+- **Molecule (CI)**: run the docker and k3s scenarios on both Ubuntu 22.04 and
+  Debian 12 (was Ubuntu-only), restoring the two-distro coverage from the
+  pre-KVM docker-driver setup.
 
 ## [1.4.0] - 2026-06-12
 

--- a/roles/docker/meta/argument_specs.yml
+++ b/roles/docker/meta/argument_specs.yml
@@ -19,6 +19,9 @@ argument_specs:
                         type: str
                         description: Defines the log driver to be used by Docker daemon.
                         default: "journald"
+                    log-opts:
+                        type: dict
+                        description: Logging driver options passed to the configured log-driver.
                     live-restore:
                         type: bool
                         description: Enables live restore of Docker when true.

--- a/roles/docker/molecule/default/converge.yml
+++ b/roles/docker/molecule/default/converge.yml
@@ -10,6 +10,9 @@
       docker_version: ""
       docker_daemon:
           log-driver: json-file
+          log-opts:
+              max-size: "10m"
+              max-file: "3"
           storage-driver: overlay2
           features:
               buildkit: true

--- a/roles/docker/molecule/default/molecule.yml
+++ b/roles/docker/molecule/default/molecule.yml
@@ -20,6 +20,7 @@ platforms:
 
     - name: docker-debian-12
       image_url: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
+      image_checksum: sha512:https://cloud.debian.org/images/cloud/bookworm/latest/SHA512SUMS
       image_arch: x86_64
       network_mode: user
       network_ssh_port: 2223

--- a/roles/docker/molecule/default/molecule.yml
+++ b/roles/docker/molecule/default/molecule.yml
@@ -18,6 +18,15 @@ platforms:
       vm_cpus: 2
       vm_memory: 2048
 
+    - name: docker-debian-12
+      image_url: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2223
+      network_ssh_user: debian
+      vm_cpus: 2
+      vm_memory: 2048
+
 provisioner:
     name: ansible
     config_options:
@@ -28,6 +37,8 @@ provisioner:
     inventory:
         host_vars:
             docker-ubuntu-22.04:
+                ansible_become: true
+            docker-debian-12:
                 ansible_become: true
     playbooks:
         converge: converge.yml

--- a/roles/k3s/molecule/default/molecule.yml
+++ b/roles/k3s/molecule/default/molecule.yml
@@ -18,6 +18,15 @@ platforms:
       vm_cpus: 2
       vm_memory: 3072
 
+    - name: k3s-debian-12
+      image_url: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2223
+      network_ssh_user: debian
+      vm_cpus: 2
+      vm_memory: 3072
+
 provisioner:
     name: ansible
     config_options:
@@ -28,6 +37,8 @@ provisioner:
     inventory:
         host_vars:
             k3s-ubuntu-22.04:
+                ansible_become: true
+            k3s-debian-12:
                 ansible_become: true
     playbooks:
         converge: converge.yml

--- a/roles/k3s/molecule/default/molecule.yml
+++ b/roles/k3s/molecule/default/molecule.yml
@@ -20,6 +20,7 @@ platforms:
 
     - name: k3s-debian-12
       image_url: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
+      image_checksum: sha512:https://cloud.debian.org/images/cloud/bookworm/latest/SHA512SUMS
       image_arch: x86_64
       network_mode: user
       network_ssh_port: 2223


### PR DESCRIPTION
## Summary

Follow-ups to the molecule/KVM work merged in #112:

- **Debian 12 coverage**: the docker and k3s molecule scenarios were reduced to a single Ubuntu 22.04 platform during the molecule-qemu switch. Re-add a Debian 12 (bookworm) cloud-image platform so both run on two distros again.
- **`docker_daemon.log-opts`**: `log-opts` is a valid `daemon.json` key but was missing from the `docker_daemon` argument spec, so passing it failed argument validation. Add it and restore log rotation (`max-size`/`max-file`) in the docker scenario.

## Test plan

- [ ] `molecule-docker` green on ubuntu-22.04 + debian-12
- [ ] `molecule-k3s` green on ubuntu-22.04 + debian-12
- [ ] Argument Specs Check green