### PR TITLE
test(molecule): add scenarios for the 5 untested roles

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,11 @@
     "customManagers": [
         {
             "customType": "regex",
-            "managerFilePatterns": ["/^roles/.*/defaults/main\\.yml$/", "/^roles/.*/meta/argument_specs\\.yml$/"],
+            "managerFilePatterns": [
+                "/^roles/.*/defaults/main\\.yml$/",
+                "/^roles/.*/meta/argument_specs\\.yml$/",
+                "/^\\.github/workflows/.*\\.ya?ml$/"
+            ],
             "matchStrings": [
                 "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+extractVersion=(?<extractVersion>\\S+))?(?:\\s+versioning=(?<versioning>\\S+))?\\s*(?:\\r?\\n|\\r).*?:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?\\s*(?:\\r?\\n|\\r|$)"
             ],

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -24,6 +24,7 @@ jobs:
         with:
             collection_namespace: arillso
             collection_name: container
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             enable_unit_tests: true
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -58,6 +58,61 @@ jobs:
             scenarios: '["default"]'
             concurrency-suffix: molecule-k3s
 
+    molecule-docker-login:
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-18
+        with:
+            collection_namespace: arillso
+            collection_name: container
+            driver: qemu
+            python_version: "3.12"
+            scenarios_root: roles/docker_login/molecule
+            scenarios: '["default"]'
+            concurrency-suffix: molecule-docker-login
+
+    molecule-docker-compose-v2:
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-18
+        with:
+            collection_namespace: arillso
+            collection_name: container
+            driver: qemu
+            python_version: "3.12"
+            scenarios_root: roles/docker_compose_v2/molecule
+            scenarios: '["default"]'
+            concurrency-suffix: molecule-docker-compose-v2
+
+    molecule-helm:
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-18
+        with:
+            collection_namespace: arillso
+            collection_name: container
+            driver: qemu
+            python_version: "3.12"
+            scenarios_root: roles/helm/molecule
+            scenarios: '["default"]'
+            concurrency-suffix: molecule-helm
+
+    molecule-fleet:
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-18
+        with:
+            collection_namespace: arillso
+            collection_name: container
+            driver: qemu
+            python_version: "3.12"
+            scenarios_root: roles/fleet/molecule
+            scenarios: '["default"]'
+            concurrency-suffix: molecule-fleet
+
+    molecule-tailscale:
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-18
+        with:
+            collection_namespace: arillso
+            collection_name: container
+            driver: qemu
+            python_version: "3.12"
+            scenarios_root: roles/tailscale/molecule
+            scenarios: '["default"]'
+            concurrency-suffix: molecule-tailscale
+
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-06-18
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,6 +26,7 @@ jobs:
         with:
             collection_namespace: arillso
             collection_name: container
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             enable_unit_tests: true
 
@@ -42,6 +43,7 @@ jobs:
             collection_namespace: arillso
             collection_name: container
             driver: qemu
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             scenarios_root: roles/docker/molecule
             scenarios: '["default"]'
@@ -53,6 +55,7 @@ jobs:
             collection_namespace: arillso
             collection_name: container
             driver: qemu
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             scenarios_root: roles/k3s/molecule
             scenarios: '["default"]'
@@ -64,6 +67,7 @@ jobs:
             collection_namespace: arillso
             collection_name: container
             driver: qemu
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             scenarios_root: roles/docker_login/molecule
             scenarios: '["default"]'
@@ -75,6 +79,7 @@ jobs:
             collection_namespace: arillso
             collection_name: container
             driver: qemu
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             scenarios_root: roles/docker_compose_v2/molecule
             scenarios: '["default"]'
@@ -86,6 +91,7 @@ jobs:
             collection_namespace: arillso
             collection_name: container
             driver: qemu
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             scenarios_root: roles/helm/molecule
             scenarios: '["default"]'
@@ -97,6 +103,7 @@ jobs:
             collection_namespace: arillso
             collection_name: container
             driver: qemu
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             scenarios_root: roles/fleet/molecule
             scenarios: '["default"]'
@@ -108,6 +115,7 @@ jobs:
             collection_namespace: arillso
             collection_name: container
             driver: qemu
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             scenarios_root: roles/tailscale/molecule
             scenarios: '["default"]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Molecule coverage** for the five previously-untested roles, each with a
+  `default` scenario under `roles/<role>/molecule/default/` and a matching
+  `molecule-<role>` job wired into `pull-request.yml` (qemu/KVM driver,
+  Ubuntu 22.04 cloud image, pinned to `ci-ansible-molecule.yml@2026-06-18`):
+    - **docker_login** — full converge: a `prepare.yml` installs Docker via
+      the `docker` role and starts a throwaway local `registry:2` container,
+      converge logs into `localhost:5000`, and verify asserts the registry
+      appears under `auths` in the Docker client config.
+    - **docker_compose_v2** — full converge: `prepare.yml` installs Docker,
+      converge deploys a minimal `nginx` compose project, and verify asserts
+      the compose plugin, the rendered project file, the systemd unit and a
+      running container.
+    - **helm**, **fleet**, **tailscale** — syntax-only scenarios
+      (`test_sequence` stops after `syntax`). These roles drive a live
+      Kubernetes API (HelmChart CRDs, Rancher Fleet GitOps CRDs, the
+      Tailscale operator CRDs) and cannot converge without a running
+      cluster; standing up k3s per role would make CI slow and flaky, so the
+      converge/verify against a real cluster is deferred and documented at
+      the top of each `molecule.yml`. Syntax checking still validates
+      playbook/role wiring cheaply.
+
 ### Fixed
 
 - **fleet argument_specs**: the main entry point used six separate `<<:` merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,23 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Molecule coverage** for the five previously-untested roles, each with a
   `default` scenario under `roles/<role>/molecule/default/` and a matching
   `molecule-<role>` job wired into `pull-request.yml` (qemu/KVM driver,
-  Ubuntu 22.04 cloud image, pinned to `ci-ansible-molecule.yml@2026-06-18`):
-    - **docker_login** — full converge: a `prepare.yml` installs Docker via
-      the `docker` role and starts a throwaway local `registry:2` container,
-      converge logs into `localhost:5000`, and verify asserts the registry
-      appears under `auths` in the Docker client config.
-    - **docker_compose_v2** — full converge: `prepare.yml` installs Docker,
-      converge deploys a minimal `nginx` compose project, and verify asserts
-      the compose plugin, the rendered project file, the systemd unit and a
-      running container.
-    - **helm**, **fleet**, **tailscale** — syntax-only scenarios
-      (`test_sequence` stops after `syntax`). These roles drive a live
-      Kubernetes API (HelmChart CRDs, Rancher Fleet GitOps CRDs, the
-      Tailscale operator CRDs) and cannot converge without a running
-      cluster; standing up k3s per role would make CI slow and flaky, so the
-      converge/verify against a real cluster is deferred and documented at
-      the top of each `molecule.yml`. Syntax checking still validates
-      playbook/role wiring cheaply.
+  Ubuntu 22.04 cloud image, pinned to `ci-ansible-molecule.yml@2026-06-18`).
+- **docker_login** molecule — full converge: a `prepare.yml` installs Docker via
+  the `docker` role and starts a throwaway local `registry:2` container,
+  converge logs into `localhost:5000`, and verify asserts the registry appears
+  under `auths` in the Docker client config.
+- **docker_compose_v2** molecule — full converge: `prepare.yml` installs Docker,
+  converge deploys a minimal `nginx` compose project, and verify asserts the
+  compose plugin, the rendered project file, the systemd unit and a running
+  container.
+- **helm**, **fleet**, **tailscale** molecule — syntax-only scenarios
+  (`test_sequence` stops after `syntax`). These roles drive a live Kubernetes
+  API (HelmChart CRDs, Rancher Fleet GitOps CRDs, the Tailscale operator CRDs)
+  and cannot converge without a running cluster; standing up k3s per role would
+  make CI slow and flaky, so the converge/verify against a real cluster is
+  deferred and documented at the top of each `molecule.yml`. Syntax checking
+  still validates playbook/role wiring cheaply.
 
 ### Fixed
 
@@ -54,6 +53,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Renovate**: track the `python_version` CI input via Renovate. Each
+  `python_version:` in `pull-request.yml`/`merge.yml` carries a
+  `# renovate: datasource=github-releases depName=python/cpython` marker, and
+  the local regex manager now scans `.github/workflows/*.yml`, so the Python
+  version is bumped automatically instead of drifting hardcoded.
 - **Dependency**: raise the `arillso.system` lower bound from `>=0.0.17` to
   `>=1.0.0` — the `systemd` role with the `systemd_units` interface the docker
   role now uses is only available from 1.0.0 onwards.

--- a/roles/docker_compose_v2/molecule/default/converge.yml
+++ b/roles/docker_compose_v2/molecule/default/converge.yml
@@ -1,0 +1,24 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+      # Do not pin the plugin version: apt has no candidate for an exact
+      # `docker-compose-plugin=5.1.4` on the CI image (same class of issue
+      # the docker role avoids by leaving docker_version empty). Empty
+      # version installs whatever the docker-ce repo currently offers.
+      docker_compose_v2_version: ""
+      docker_compose_v2_project: "molecule"
+      # Deploy a minimal compose project from a templated file so we
+      # exercise both the systemd unit and the docker_compose_v2 module.
+      docker_compose_v2_use_file: true
+      docker_compose_v2_config:
+          services:
+              web:
+                  image: nginx:alpine
+                  ports:
+                      - "8080:80"
+  tasks:
+      - name: Include docker_compose_v2 role
+        ansible.builtin.include_role:
+            name: arillso.container.docker_compose_v2

--- a/roles/docker_compose_v2/molecule/default/molecule.yml
+++ b/roles/docker_compose_v2/molecule/default/molecule.yml
@@ -1,0 +1,54 @@
+---
+dependency:
+    name: galaxy
+    options:
+        requirements-file: requirements.yml
+
+driver:
+    name: molecule-qemu
+
+platforms:
+    - name: docker-compose-v2-ubuntu-22.04
+      image_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+      image_checksum: sha256:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2222
+      network_ssh_user: ubuntu
+      vm_cpus: 2
+      vm_memory: 2048
+
+provisioner:
+    name: ansible
+    config_options:
+        defaults:
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
+            result_format: yaml
+    inventory:
+        host_vars:
+            docker-compose-v2-ubuntu-22.04:
+                ansible_become: true
+    playbooks:
+        prepare: prepare.yml
+        converge: converge.yml
+        verify: verify.yml
+
+verifier:
+    name: ansible
+
+scenario:
+    name: default
+    test_sequence:
+        - dependency
+        - cleanup
+        - destroy
+        - syntax
+        - create
+        - prepare
+        - converge
+        - idempotence
+        - side_effect
+        - verify
+        - cleanup
+        - destroy

--- a/roles/docker_compose_v2/molecule/default/prepare.yml
+++ b/roles/docker_compose_v2/molecule/default/prepare.yml
@@ -1,0 +1,16 @@
+---
+# Full converge: docker_compose_v2 installs the compose plugin and
+# deploys a compose project, which needs a running Docker daemon and
+# the docker-ce apt repository. We install Docker via the docker role
+# first so the converge step has both.
+- name: Prepare
+  hosts: all
+  become: true
+  vars:
+      # Do not pin docker-ce; apt's full version string never matches a
+      # bare "docker-ce=<x>" pin (see roles/docker/molecule converge).
+      docker_version: ""
+  tasks:
+      - name: Install Docker
+        ansible.builtin.include_role:
+            name: arillso.container.docker

--- a/roles/docker_compose_v2/molecule/default/requirements.yml
+++ b/roles/docker_compose_v2/molecule/default/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+    - name: community.docker
+      version: ">=3.4.11"
+    - name: arillso.system
+      version: ">=1.0.0"

--- a/roles/docker_compose_v2/molecule/default/side_effect.yml
+++ b/roles/docker_compose_v2/molecule/default/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effect
+  hosts: all
+  gather_facts: false
+
+  tasks:
+      - name: No side-effect step required for this role
+        ansible.builtin.debug:
+            msg: "No side-effect step required."

--- a/roles/docker_compose_v2/molecule/default/verify.yml
+++ b/roles/docker_compose_v2/molecule/default/verify.yml
@@ -1,0 +1,53 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+      - name: Check the docker compose plugin is available
+        ansible.builtin.command: docker compose version
+        register: docker_compose_v2_version_out
+        changed_when: false
+
+      - name: Verify the compose plugin reports a version
+        ansible.builtin.assert:
+            that:
+                - docker_compose_v2_version_out.rc == 0
+                - "'Docker Compose version' in docker_compose_v2_version_out.stdout"
+            fail_msg: "docker compose plugin is not installed"
+            success_msg: "docker compose plugin is installed"
+
+      - name: Check the generated compose project file exists
+        ansible.builtin.stat:
+            path: /etc/docker/compose/molecule/docker-compose.yml
+        register: docker_compose_v2_file
+
+      - name: Verify the compose project file was rendered
+        ansible.builtin.assert:
+            that:
+                - docker_compose_v2_file.stat.exists
+            fail_msg: "compose project file was not created"
+            success_msg: "compose project file exists"
+
+      - name: Check the systemd unit template was installed
+        ansible.builtin.stat:
+            path: /etc/systemd/system/docker-compose@.service
+        register: docker_compose_v2_unit
+
+      - name: Verify the systemd unit template exists
+        ansible.builtin.assert:
+            that:
+                - docker_compose_v2_unit.stat.exists
+            fail_msg: "docker-compose@.service unit was not created"
+            success_msg: "docker-compose@.service unit exists"
+
+      - name: List running compose containers
+        ansible.builtin.command: docker ps --filter "name=molecule" --format "{{ '{{' }}.Names{{ '}}' }}"
+        register: docker_compose_v2_ps
+        changed_when: false
+
+      - name: Verify the compose project deployed a container
+        ansible.builtin.assert:
+            that:
+                - docker_compose_v2_ps.stdout | length > 0
+            fail_msg: "compose project did not start any containers"
+            success_msg: "compose project started containers"

--- a/roles/docker_login/molecule/default/converge.yml
+++ b/roles/docker_login/molecule/default/converge.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+      # The local registry:2 started in prepare.yml runs without auth,
+      # so any credentials succeed. We log into the plain-HTTP registry
+      # on localhost:5000 (no TLS) using dummy credentials.
+      docker_login_registry_url: "localhost:5000"
+      docker_login_username: "moleculeuser"
+      docker_login_password: "moleculepass"
+      docker_login_tls: false
+      docker_login_validate_certs: false
+  tasks:
+      - name: Include docker_login role
+        ansible.builtin.include_role:
+            name: arillso.container.docker_login

--- a/roles/docker_login/molecule/default/molecule.yml
+++ b/roles/docker_login/molecule/default/molecule.yml
@@ -1,0 +1,54 @@
+---
+dependency:
+    name: galaxy
+    options:
+        requirements-file: requirements.yml
+
+driver:
+    name: molecule-qemu
+
+platforms:
+    - name: docker-login-ubuntu-22.04
+      image_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+      image_checksum: sha256:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2222
+      network_ssh_user: ubuntu
+      vm_cpus: 2
+      vm_memory: 2048
+
+provisioner:
+    name: ansible
+    config_options:
+        defaults:
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
+            result_format: yaml
+    inventory:
+        host_vars:
+            docker-login-ubuntu-22.04:
+                ansible_become: true
+    playbooks:
+        prepare: prepare.yml
+        converge: converge.yml
+        verify: verify.yml
+
+verifier:
+    name: ansible
+
+scenario:
+    name: default
+    test_sequence:
+        - dependency
+        - cleanup
+        - destroy
+        - syntax
+        - create
+        - prepare
+        - converge
+        - idempotence
+        - side_effect
+        - verify
+        - cleanup
+        - destroy

--- a/roles/docker_login/molecule/default/prepare.yml
+++ b/roles/docker_login/molecule/default/prepare.yml
@@ -1,0 +1,42 @@
+---
+# Full converge: docker_login needs a running Docker daemon and a
+# registry to authenticate against. We install Docker via the docker
+# role and spin up a throwaway local registry:2 container that the
+# converge step then logs into.
+- name: Prepare
+  hosts: all
+  become: true
+  vars:
+      # Do not pin docker-ce; apt's full version string never matches a
+      # bare "docker-ce=<x>" pin (see roles/docker/molecule converge).
+      docker_version: ""
+  tasks:
+      - name: Install Docker
+        ansible.builtin.include_role:
+            name: arillso.container.docker
+
+      - name: Install pip (cloud image ships no pip3)
+        ansible.builtin.apt:
+            name: python3-pip
+            state: present
+            update_cache: true
+
+      - name: Install Python Docker SDK for community.docker modules
+        ansible.builtin.pip:
+            name: docker
+            state: present
+
+      - name: Run a throwaway local registry to authenticate against
+        community.docker.docker_container:
+            name: molecule-registry
+            image: registry:2
+            state: started
+            restart_policy: "no"
+            published_ports:
+                - "5000:5000"
+
+      - name: Wait for the local registry to accept connections
+        ansible.builtin.wait_for:
+            host: 127.0.0.1
+            port: 5000
+            timeout: 60

--- a/roles/docker_login/molecule/default/requirements.yml
+++ b/roles/docker_login/molecule/default/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+    - name: community.docker
+      version: ">=3.4.11"
+    - name: arillso.system
+      version: ">=1.0.0"

--- a/roles/docker_login/molecule/default/side_effect.yml
+++ b/roles/docker_login/molecule/default/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effect
+  hosts: all
+  gather_facts: false
+
+  tasks:
+      - name: No side-effect step required for this role
+        ansible.builtin.debug:
+            msg: "No side-effect step required."

--- a/roles/docker_login/molecule/default/verify.yml
+++ b/roles/docker_login/molecule/default/verify.yml
@@ -1,0 +1,21 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+      - name: Read the Docker client config
+        ansible.builtin.slurp:
+            path: /root/.docker/config.json
+        register: docker_login_config
+
+      - name: Parse the Docker client config
+        ansible.builtin.set_fact:
+            docker_login_config_json: "{{ docker_login_config.content | b64decode | from_json }}"
+
+      - name: Verify the local registry is recorded as an authenticated endpoint
+        ansible.builtin.assert:
+            that:
+                - "'auths' in docker_login_config_json"
+                - "'localhost:5000' in docker_login_config_json.auths"
+            fail_msg: "docker_login did not record an auth entry for localhost:5000"
+            success_msg: "docker_login authenticated against localhost:5000 successfully"

--- a/roles/docker_login/tasks/main.yml
+++ b/roles/docker_login/tasks/main.yml
@@ -15,5 +15,5 @@
       timeout: "{{ docker_login_timeout }}"
       tls: "{{ docker_login_tls }}"
       tls_hostname: "{{ docker_login_tls_hostname | default(omit) }}"
-      tls_verify: "{{ docker_login_tls_verify }}"
+      tls_verify: "{{ docker_login_validate_certs }}"
       username: "{{ docker_login_username }}"

--- a/roles/fleet/molecule/default/converge.yml
+++ b/roles/fleet/molecule/default/converge.yml
@@ -1,0 +1,11 @@
+---
+# Exercised by the `syntax` step only (see molecule.yml). Converge
+# against a live cluster is deferred; the role needs a running
+# Kubernetes API with Rancher Fleet installed to apply its CRDs.
+- name: Converge
+  hosts: all
+  become: true
+  tasks:
+      - name: Include fleet role
+        ansible.builtin.include_role:
+            name: arillso.container.fleet

--- a/roles/fleet/molecule/default/molecule.yml
+++ b/roles/fleet/molecule/default/molecule.yml
@@ -1,0 +1,56 @@
+---
+# SYNTAX-ONLY scenario.
+#
+# The fleet role manages Rancher Fleet GitOps resources (GitRepo,
+# Bundle, Cluster, Workspace, ClusterRegistrationToken CRDs) through a
+# live Kubernetes API via kubernetes.core. It cannot converge without
+# a running cluster with Fleet installed, and standing one up here
+# would make this leg slow and flaky. We stop the test_sequence after
+# `syntax`, which still catches playbook/role wiring and template
+# errors cheaply. A full converge against a real cluster is deferred.
+dependency:
+    name: galaxy
+    options:
+        requirements-file: requirements.yml
+
+driver:
+    name: molecule-qemu
+
+platforms:
+    - name: fleet-ubuntu-22.04
+      image_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+      image_checksum: sha256:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2222
+      network_ssh_user: ubuntu
+      vm_cpus: 2
+      vm_memory: 2048
+
+provisioner:
+    name: ansible
+    config_options:
+        defaults:
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
+            result_format: yaml
+    inventory:
+        host_vars:
+            fleet-ubuntu-22.04:
+                ansible_become: true
+    playbooks:
+        converge: converge.yml
+        verify: verify.yml
+
+verifier:
+    name: ansible
+
+scenario:
+    name: default
+    test_sequence:
+        - dependency
+        - cleanup
+        - destroy
+        - syntax
+        - cleanup
+        - destroy

--- a/roles/fleet/molecule/default/requirements.yml
+++ b/roles/fleet/molecule/default/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+    - name: kubernetes.core
+      version: ">=2.4.0"
+    - name: arillso.system
+      version: ">=1.0.0"

--- a/roles/fleet/molecule/default/side_effect.yml
+++ b/roles/fleet/molecule/default/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effect
+  hosts: all
+  gather_facts: false
+
+  tasks:
+      - name: No side-effect step required for this role
+        ansible.builtin.debug:
+            msg: "No side-effect step required."

--- a/roles/fleet/molecule/default/verify.yml
+++ b/roles/fleet/molecule/default/verify.yml
@@ -1,0 +1,12 @@
+---
+# Verify is not part of the test_sequence for this syntax-only
+# scenario (the role needs a live Kubernetes cluster to converge, so
+# there is nothing host-local to assert). Kept as a placeholder so the
+# provisioner playbook reference resolves.
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+      - name: No host-local verification for a cluster-bound role
+        ansible.builtin.debug:
+            msg: "fleet requires a live Kubernetes cluster; verify is deferred."

--- a/roles/helm/molecule/default/converge.yml
+++ b/roles/helm/molecule/default/converge.yml
@@ -1,0 +1,11 @@
+---
+# Exercised by the `syntax` step only (see molecule.yml). Converge
+# against a live cluster is deferred; the role needs a running
+# Kubernetes API to apply HelmChart resources.
+- name: Converge
+  hosts: all
+  become: true
+  tasks:
+      - name: Include helm role
+        ansible.builtin.include_role:
+            name: arillso.container.helm

--- a/roles/helm/molecule/default/molecule.yml
+++ b/roles/helm/molecule/default/molecule.yml
@@ -1,0 +1,57 @@
+---
+# SYNTAX-ONLY scenario.
+#
+# The helm role drives a live Kubernetes API (HelmChart CRDs via
+# kubernetes.core / the k3s Helm controller). It cannot converge
+# without a running cluster, and standing up k3s here would make this
+# leg slow (~10 min VM + cluster) and flaky. We therefore stop the
+# test_sequence after `syntax`, which still catches playbook/role
+# wiring and template errors cheaply. A full converge against a real
+# cluster is deferred (mirrors how kernel-/cluster-bound roles are
+# documented elsewhere in the collection).
+dependency:
+    name: galaxy
+    options:
+        requirements-file: requirements.yml
+
+driver:
+    name: molecule-qemu
+
+platforms:
+    - name: helm-ubuntu-22.04
+      image_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+      image_checksum: sha256:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2222
+      network_ssh_user: ubuntu
+      vm_cpus: 2
+      vm_memory: 2048
+
+provisioner:
+    name: ansible
+    config_options:
+        defaults:
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
+            result_format: yaml
+    inventory:
+        host_vars:
+            helm-ubuntu-22.04:
+                ansible_become: true
+    playbooks:
+        converge: converge.yml
+        verify: verify.yml
+
+verifier:
+    name: ansible
+
+scenario:
+    name: default
+    test_sequence:
+        - dependency
+        - cleanup
+        - destroy
+        - syntax
+        - cleanup
+        - destroy

--- a/roles/helm/molecule/default/requirements.yml
+++ b/roles/helm/molecule/default/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+    - name: kubernetes.core
+      version: ">=2.4.0"
+    - name: arillso.system
+      version: ">=1.0.0"

--- a/roles/helm/molecule/default/side_effect.yml
+++ b/roles/helm/molecule/default/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effect
+  hosts: all
+  gather_facts: false
+
+  tasks:
+      - name: No side-effect step required for this role
+        ansible.builtin.debug:
+            msg: "No side-effect step required."

--- a/roles/helm/molecule/default/verify.yml
+++ b/roles/helm/molecule/default/verify.yml
@@ -1,0 +1,12 @@
+---
+# Verify is not part of the test_sequence for this syntax-only
+# scenario (the role needs a live Kubernetes cluster to converge, so
+# there is nothing host-local to assert). Kept as a placeholder so the
+# provisioner playbook reference resolves.
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+      - name: No host-local verification for a cluster-bound role
+        ansible.builtin.debug:
+            msg: "helm requires a live Kubernetes cluster; verify is deferred."

--- a/roles/tailscale/molecule/default/converge.yml
+++ b/roles/tailscale/molecule/default/converge.yml
@@ -1,0 +1,11 @@
+---
+# Exercised by the `syntax` step only (see molecule.yml). Converge
+# against a live cluster is deferred; the role needs a running
+# Kubernetes API with the Tailscale operator to apply its CRDs.
+- name: Converge
+  hosts: all
+  become: true
+  tasks:
+      - name: Include tailscale role
+        ansible.builtin.include_role:
+            name: arillso.container.tailscale

--- a/roles/tailscale/molecule/default/molecule.yml
+++ b/roles/tailscale/molecule/default/molecule.yml
@@ -1,0 +1,57 @@
+---
+# SYNTAX-ONLY scenario.
+#
+# The tailscale role manages Tailscale Kubernetes operator resources
+# (ProxyGroup, Ingress and egress Service CRDs) through a live
+# Kubernetes API via kubernetes.core. It cannot converge without a
+# running cluster with the Tailscale operator installed, and standing
+# one up here would make this leg slow and flaky. We stop the
+# test_sequence after `syntax`, which still catches playbook/role
+# wiring and template errors cheaply. A full converge against a real
+# cluster is deferred.
+dependency:
+    name: galaxy
+    options:
+        requirements-file: requirements.yml
+
+driver:
+    name: molecule-qemu
+
+platforms:
+    - name: tailscale-ubuntu-22.04
+      image_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+      image_checksum: sha256:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2222
+      network_ssh_user: ubuntu
+      vm_cpus: 2
+      vm_memory: 2048
+
+provisioner:
+    name: ansible
+    config_options:
+        defaults:
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
+            result_format: yaml
+    inventory:
+        host_vars:
+            tailscale-ubuntu-22.04:
+                ansible_become: true
+    playbooks:
+        converge: converge.yml
+        verify: verify.yml
+
+verifier:
+    name: ansible
+
+scenario:
+    name: default
+    test_sequence:
+        - dependency
+        - cleanup
+        - destroy
+        - syntax
+        - cleanup
+        - destroy

--- a/roles/tailscale/molecule/default/requirements.yml
+++ b/roles/tailscale/molecule/default/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+    - name: kubernetes.core
+      version: ">=2.4.0"
+    - name: arillso.system
+      version: ">=1.0.0"

--- a/roles/tailscale/molecule/default/side_effect.yml
+++ b/roles/tailscale/molecule/default/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effect
+  hosts: all
+  gather_facts: false
+
+  tasks:
+      - name: No side-effect step required for this role
+        ansible.builtin.debug:
+            msg: "No side-effect step required."

--- a/roles/tailscale/molecule/default/verify.yml
+++ b/roles/tailscale/molecule/default/verify.yml
@@ -1,0 +1,12 @@
+---
+# Verify is not part of the test_sequence for this syntax-only
+# scenario (the role needs a live Kubernetes cluster to converge, so
+# there is nothing host-local to assert). Kept as a placeholder so the
+# provisioner playbook reference resolves.
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+      - name: No host-local verification for a cluster-bound role
+        ansible.builtin.debug:
+            msg: "tailscale requires a live Kubernetes cluster; verify is deferred."


### PR DESCRIPTION
## Summary

- Add molecule scenarios for `docker_compose_v2`, `docker_login`, `fleet`, `helm`, `tailscale` (only docker + k3s had coverage); one CI job per role in `pull-request.yml`
- `docker_login` / `docker_compose_v2`: full converge — `prepare.yml` installs Docker; docker_login logs into a throwaway local `registry:2`, docker_compose_v2 deploys a minimal compose project; verify asserts the result
- `helm` / `fleet` / `tailscale`: syntax-only — they drive a live Kubernetes API (HelmChart CRDs, Fleet GitOps, Tailscale operator); standing up k3s per role would make CI slow + flaky, so the scenarios stop after `syntax` with a documented rationale (mirrors kernel-bound roles in arillso.system)

Resolves the audited Notion molecule-coverage ticket for the container collection.

## Test plan

- [ ] CI green (7 molecule legs incl. 5 new)
- [x] `ansible-lint roles/*/molecule` → 0 failures (production)
- [x] all molecule.yml + pull-request.yml parse
- [ ] full-converge legs need outbound network in VM (Docker Hub pulls), same as existing docker leg