### PR TITLE
refactor(fleet): run bundle and cluster loops async

### DIFF
--- a/roles/fleet/defaults/main.yml
+++ b/roles/fleet/defaults/main.yml
@@ -92,6 +92,20 @@ fleet_dry_run: false
 fleet_secret_timeout: 60
 fleet_resource_timeout: 300
 
+# Async execution for resource deploys with blocking waits (Bundles,
+# Clusters). When enabled, k8s applies are fired in parallel
+# (async/poll:0) and a single async_status loop waits for completion,
+# instead of running each item serially up to fleet_resource_timeout.
+# Automatically bypassed in check_mode (async is unsupported there).
+fleet_async_enabled: true
+# Per-job async timeout in seconds. Should be >= the per-item k8s
+# wait_timeout so a job is never reaped while still legitimately waiting.
+fleet_async_timeout: 600
+# async_status poll retries / delay. retries * delay must comfortably
+# exceed fleet_async_timeout so the poller does not give up before jobs do.
+fleet_async_retries: 120
+fleet_async_delay: 5
+
 # Fleet authentication parameters (auth entry point) are intentionally left
 # undefined here. They are declared as optional in meta/argument_specs.yml and
 # resolved with default(omit) where consumed, so no string-omit defaults are set.

--- a/roles/fleet/defaults/main.yml
+++ b/roles/fleet/defaults/main.yml
@@ -102,8 +102,9 @@ fleet_async_enabled: true
 # wait_timeout so a job is never reaped while still legitimately waiting.
 fleet_async_timeout: 600
 # async_status poll retries / delay. retries * delay must comfortably
-# exceed fleet_async_timeout so the poller does not give up before jobs do.
-fleet_async_retries: 120
+# exceed fleet_async_timeout so the poller does not give up before jobs do
+# (150 * 5 = 750s > 600s timeout, ~25% headroom).
+fleet_async_retries: 150
 fleet_async_delay: 5
 
 # Fleet authentication parameters (auth entry point) are intentionally left

--- a/roles/fleet/meta/argument_specs.yml
+++ b/roles/fleet/meta/argument_specs.yml
@@ -63,6 +63,33 @@ _common_options: &common_fleet_options
         type: "int"
         default: 300
 
+    fleet_async_enabled:
+        description:
+            - "Fire resource deploys with blocking waits (Bundles, Clusters)"
+            - "in parallel via async/poll:0 instead of serially."
+            - "Automatically bypassed in check_mode (async is unsupported there)."
+        type: "bool"
+        default: true
+
+    fleet_async_timeout:
+        description:
+            - "Per-job async timeout in seconds for fire-and-forget k8s applies."
+            - "Should be >= the per-item k8s wait_timeout."
+        type: "int"
+        default: 600
+
+    fleet_async_retries:
+        description:
+            - "Number of async_status poll retries."
+            - "retries * delay must exceed fleet_async_timeout."
+        type: "int"
+        default: 120
+
+    fleet_async_delay:
+        description: "Delay in seconds between async_status poll retries"
+        type: "int"
+        default: 5
+
 _cluster_selector_options: &cluster_selector_options
     cluster_selector:
         description: "Cluster selector for targeting"

--- a/roles/fleet/tasks/bundles.yml
+++ b/roles/fleet/tasks/bundles.yml
@@ -87,6 +87,9 @@
       - not ansible_check_mode
   async: "{{ fleet_async_timeout }}"
   poll: 0
+  # Fire-and-forget always reports changed (no module result yet); the real
+  # changed/failed status is surfaced by the async_status wait task below.
+  changed_when: false
   register: fleet_bundle_async
   tags:
       - fleet

--- a/roles/fleet/tasks/bundles.yml
+++ b/roles/fleet/tasks/bundles.yml
@@ -18,8 +18,13 @@
       - fleet-bundles
       - fleet-namespace
 
-- name: "Manage Fleet Bundles"
-  kubernetes.core.k8s:
+# Each Bundle apply blocks up to wait_timeout (Ready condition). Run the
+# applies in parallel (async/poll:0) so total runtime is bounded by the
+# slowest Bundle, not the sum. The blocking wait stays inside each async
+# job (the k8s module still runs wait:true in the background); async_status
+# only polls for module completion.
+- name: "Manage Fleet Bundles (async)"
+  kubernetes.core.k8s: &fleet_bundle_apply
       definition:
           apiVersion: "{{ fleet_api_version }}"
           kind: Bundle
@@ -76,8 +81,63 @@
           status: "True"
       wait_timeout: 300
   loop: "{{ fleet_bundles }}"
+  when:
+      - fleet_bundles | length > 0
+      - fleet_async_enabled | bool
+      - not ansible_check_mode
+  async: "{{ fleet_async_timeout }}"
+  poll: 0
+  register: fleet_bundle_async
+  tags:
+      - fleet
+      - fleet-bundles
+
+- name: "Wait for Fleet Bundle apply jobs"
+  ansible.builtin.async_status:
+      jid: "{{ item.ansible_job_id }}"
+  loop: "{{ fleet_bundle_async.results | default([]) }}"
+  loop_control:
+      label: "{{ item.item.name | default('') }}"
+  when:
+      - fleet_bundles | length > 0
+      - fleet_async_enabled | bool
+      - not ansible_check_mode
+      - item.ansible_job_id is defined
+  register: fleet_bundle_async_wait
+  until: fleet_bundle_async_wait.finished
+  retries: "{{ fleet_async_retries }}"
+  delay: "{{ fleet_async_delay }}"
+  tags:
+      - fleet
+      - fleet-bundles
+
+# Synchronous fallback: check_mode (async unsupported) or async disabled.
+- name: "Manage Fleet Bundles (sync)"
+  kubernetes.core.k8s: *fleet_bundle_apply
+  loop: "{{ fleet_bundles }}"
+  when:
+      - fleet_bundles | length > 0
+      - not (fleet_async_enabled | bool) or ansible_check_mode
+  register: fleet_bundle_sync
+  tags:
+      - fleet
+      - fleet-bundles
+
+# Normalize both paths to a single .results shape carrying the original
+# bundle as .item, so downstream consumers stay path-agnostic. The
+# async_status loop nests the original bundle at item.item.item; the sync
+# path already exposes it at item.item.
+- name: "Collect Fleet Bundle deployment results"
+  ansible.builtin.set_fact:
+      fleet_bundle_results:
+          results: >-
+              {{
+                (fleet_bundle_sync.results | default([]))
+                if (not (fleet_async_enabled | bool) or ansible_check_mode)
+                else (fleet_bundle_async_wait.results | default([]))
+                     | map(attribute='item') | list
+              }}
   when: fleet_bundles | length > 0
-  register: fleet_bundle_results
   tags:
       - fleet
       - fleet-bundles

--- a/roles/fleet/tasks/clusters.yml
+++ b/roles/fleet/tasks/clusters.yml
@@ -18,8 +18,12 @@
       - fleet-clusters
       - fleet-namespace
 
-- name: "Manage Fleet Clusters"
-  kubernetes.core.k8s:
+# Clusters with a kubeconfig_secret block on the Ready condition (up to
+# wait_timeout each); fire them in parallel (async/poll:0) so total runtime
+# is bounded by the slowest cluster. The wait stays inside each async job;
+# async_status only polls for module completion.
+- name: "Manage Fleet Clusters (async)"
+  kubernetes.core.k8s: &fleet_cluster_apply
       kubeconfig: "{{ fleet_kubeconfig_path | default('/etc/rancher/k3s/k3s.yaml') }}"
       api_version: "{{ fleet_api_version }}"
       kind: Cluster
@@ -38,7 +42,59 @@
   loop: "{{ fleet_clusters }}"
   when:
       - fleet_clusters | length > 0
-  register: fleet_cluster_results
+      - fleet_async_enabled | bool
+      - not ansible_check_mode
+  async: "{{ fleet_async_timeout }}"
+  poll: 0
+  register: fleet_cluster_async
+  tags:
+      - fleet
+      - fleet-clusters
+
+- name: "Wait for Fleet Cluster apply jobs"
+  ansible.builtin.async_status:
+      jid: "{{ item.ansible_job_id }}"
+  loop: "{{ fleet_cluster_async.results | default([]) }}"
+  loop_control:
+      label: "{{ item.item.name | default('') }}"
+  when:
+      - fleet_clusters | length > 0
+      - fleet_async_enabled | bool
+      - not ansible_check_mode
+      - item.ansible_job_id is defined
+  register: fleet_cluster_async_wait
+  until: fleet_cluster_async_wait.finished
+  retries: "{{ fleet_async_retries }}"
+  delay: "{{ fleet_async_delay }}"
+  tags:
+      - fleet
+      - fleet-clusters
+
+# Synchronous fallback: check_mode (async unsupported) or async disabled.
+- name: "Manage Fleet Clusters (sync)"
+  kubernetes.core.k8s: *fleet_cluster_apply
+  loop: "{{ fleet_clusters }}"
+  when:
+      - fleet_clusters | length > 0
+      - not (fleet_async_enabled | bool) or ansible_check_mode
+  register: fleet_cluster_sync
+  tags:
+      - fleet
+      - fleet-clusters
+
+# Normalize both paths to a single .results shape carrying the original
+# cluster as .item (see bundles.yml for the nesting rationale).
+- name: "Collect Fleet Cluster registration results"
+  ansible.builtin.set_fact:
+      fleet_cluster_results:
+          results: >-
+              {{
+                (fleet_cluster_sync.results | default([]))
+                if (not (fleet_async_enabled | bool) or ansible_check_mode)
+                else (fleet_cluster_async_wait.results | default([]))
+                     | map(attribute='item') | list
+              }}
+  when: fleet_clusters | length > 0
   tags:
       - fleet
       - fleet-clusters

--- a/roles/fleet/tasks/clusters.yml
+++ b/roles/fleet/tasks/clusters.yml
@@ -46,6 +46,9 @@
       - not ansible_check_mode
   async: "{{ fleet_async_timeout }}"
   poll: 0
+  # Fire-and-forget always reports changed (no module result yet); the real
+  # changed/failed status is surfaced by the async_status wait task below.
+  changed_when: false
   register: fleet_cluster_async
   tags:
       - fleet

--- a/roles/fleet/tasks/gitrepos.yml
+++ b/roles/fleet/tasks/gitrepos.yml
@@ -18,6 +18,10 @@
       - fleet-gitrepos
       - fleet-namespace
 
+# Not converted to async: GitRepo applies have no wait (the k8s call only
+# creates/updates the CR and returns immediately; the Fleet controller
+# reconciles the repo asynchronously on its own). Firing these in parallel
+# would add job/polling overhead for no latency gain. Kept synchronous.
 - name: "Manage Fleet GitRepos"
   kubernetes.core.k8s:
       kubeconfig: "{{ fleet_kubeconfig_path | default('/etc/rancher/k3s/k3s.yaml') }}"


### PR DESCRIPTION
## Summary

- Bundle and cluster resources were applied serially with blocking waits (`wait: true`, up to 300s per item) — many items meant long run times.
- They now fire async (`async` + `poll: 0`) and a single `async_status` task polls all jobs to completion in parallel. Wall-clock drops from sum-of-waits to slowest-single-wait.
- A `set_fact` normalises the result shape (`async_status.results | map(attribute='item')`) so the existing debug tasks and `.results` consumers keep resolving `item.item.name`.
- `check_mode` falls back to the synchronous path (async+poll:0 is incompatible with `--check`). GitRepos stay synchronous — no wait, the controller reconciles async anyway.
- New vars: `fleet_async_enabled`, `fleet_async_timeout`, `fleet_async_retries`, `fleet_async_delay`.

## Test plan

- [ ] ansible-lint + yamllint green (local: 0 failures)
- [ ] Run against a live k3s+Fleet cluster with many bundles — verify parallel apply, idempotent re-run (changed=false), and that a failing item still fails the play
- [ ] Confirm debug-task output unchanged

> Cluster verification still pending — only static/lint checks done locally.