### PR TITLE
refactor(fleet): make bundle readiness wait configurable

### DIFF
--- a/roles/fleet/defaults/main.yml
+++ b/roles/fleet/defaults/main.yml
@@ -92,6 +92,16 @@ fleet_dry_run: false
 fleet_secret_timeout: 60
 fleet_resource_timeout: 300
 
+# Whether "Manage Fleet Bundles" blocks until each Bundle reports Ready.
+# Bundles are applied in a serial loop, so with wait enabled the play time
+# grows with the number of bundles (up to fleet_bundle_wait_timeout each).
+# Set false (globally, or per bundle via `wait: false` on the item) to apply
+# stable bundles fire-and-forget and let Fleet reconcile them asynchronously,
+# trading the readiness gate for a much shorter run. Mirrors the per-item
+# wait handling already used in clusters.yml.
+fleet_bundle_wait: true
+fleet_bundle_wait_timeout: 300
+
 # Fleet authentication parameters (auth entry point) are intentionally left
 # undefined here. They are declared as optional in meta/argument_specs.yml and
 # resolved with default(omit) where consumed, so no string-omit defaults are set.

--- a/roles/fleet/meta/argument_specs.yml
+++ b/roles/fleet/meta/argument_specs.yml
@@ -63,6 +63,16 @@ _common_options: &common_fleet_options
         type: "int"
         default: 300
 
+    fleet_bundle_wait:
+        description: "Whether Manage Fleet Bundles waits for each Bundle to report Ready (per-bundle overridable via the bundle's wait key)"
+        type: "bool"
+        default: true
+
+    fleet_bundle_wait_timeout:
+        description: "Default seconds to wait for a Bundle to report Ready when waiting is enabled"
+        type: "int"
+        default: 300
+
 _cluster_selector_options: &cluster_selector_options
     cluster_selector:
         description: "Cluster selector for targeting"
@@ -413,6 +423,12 @@ _bundle_options: &bundle_options
                 description: "Pause Bundle deployment"
                 type: "bool"
                 default: false
+            wait:
+                description: "Wait for the Bundle to report Ready (overrides fleet_bundle_wait)"
+                type: "bool"
+            wait_timeout:
+                description: "Seconds to wait for Ready when wait is enabled (overrides fleet_bundle_wait_timeout)"
+                type: "int"
             keep_resources:
                 description: "Keep resources when Bundle is deleted"
                 type: "bool"

--- a/roles/fleet/tasks/bundles.yml
+++ b/roles/fleet/tasks/bundles.yml
@@ -70,11 +70,12 @@
               diff:
                   comparePatches: "{{ item.diff.compare_patches | default([]) }}"
       state: "{{ fleet_state }}"
-      wait: true
-      wait_condition:
-          type: Ready
-          status: "True"
-      wait_timeout: 300
+      # Per-bundle override of the readiness gate, falling back to the role
+      # default. When wait is false the Bundle is applied without blocking on
+      # Ready, so a long serial loop no longer stacks up wait_timeout per item.
+      wait: "{{ item.wait | default(fleet_bundle_wait) | bool }}"
+      wait_condition: "{{ {'type': 'Ready', 'status': 'True'} if (item.wait | default(fleet_bundle_wait) | bool) else omit }}"
+      wait_timeout: "{{ item.wait_timeout | default(fleet_bundle_wait_timeout) | int if (item.wait | default(fleet_bundle_wait) | bool) else omit }}"
   loop: "{{ fleet_bundles }}"
   when: fleet_bundles | length > 0
   register: fleet_bundle_results


### PR DESCRIPTION
## Summary

- The "Manage Fleet Bundles" task waited for each bundle to become Ready with a hardcoded 300s timeout, so a serial loop over many bundles stacked up the wait per item.
- Make `wait`/`wait_timeout` overridable per bundle and via `fleet_bundle_wait` defaults (mirroring `clusters.yml`), so stable bundles can be applied fire-and-forget. The registered result shape is unchanged.

## Test plan

- [ ] `ansible-lint roles/fleet/` green (production profile)
- [ ] CI green
- [ ] Existing behaviour preserved when `fleet_bundle_wait` left at default (true)