### PR TITLE
test(integration): add docker_compose_v2, fleet and tailscale targets

### DIFF
--- a/tests/integration/targets/docker_compose_v2/aliases
+++ b/tests/integration/targets/docker_compose_v2/aliases
@@ -1,0 +1,3 @@
+destructive
+needs/root
+needs/privileged

--- a/tests/integration/targets/docker_compose_v2/meta/main.yml
+++ b/tests/integration/targets/docker_compose_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+    - docker

--- a/tests/integration/targets/docker_compose_v2/tasks/main.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/main.yml
@@ -46,7 +46,7 @@
       fail_msg: "docker_compose_v2 did not start the expected service container"
       success_msg: "docker_compose_v2 brought the compose project up correctly"
 
-- name: Apply docker_compose_v2 role again (idempotency check)
+- name: Apply docker_compose_v2 role again
   ansible.builtin.include_role:
       name: arillso.container.docker_compose_v2
   vars:
@@ -54,7 +54,21 @@
       docker_compose_v2_use_file: false
       docker_compose_v2_config: "{{ compose_test_definition }}"
       docker_compose_v2_state: present
-  register: compose_second_run
+
+- name: Gather the container again after the second apply
+  community.docker.docker_container_info:
+      name: integration-compose-web
+  register: compose_container_rerun
+
+- name: Assert the second apply was a no-op (container not recreated)
+  ansible.builtin.assert:
+      that:
+          - compose_container_rerun.exists
+          - compose_container_rerun.container.Id == compose_container.container.Id
+      fail_msg: >-
+          docker_compose_v2 recreated the container on a no-op re-run (not
+          idempotent): {{ compose_container.container.Id }} -> {{ compose_container_rerun.container.Id }}
+      success_msg: "docker_compose_v2 second apply was idempotent (same container Id)"
 
 - name: Tear down the compose project
   ansible.builtin.include_role:

--- a/tests/integration/targets/docker_compose_v2/tasks/main.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+# Integration tests for docker_compose_v2 role
+# Covers the main path: install the compose plugin, render an inline project
+# definition, bring it up via community.docker.docker_compose_v2, verify the
+# container is running, check idempotency, then tear the project down again.
+
+- name: Define inline Docker Compose project for the test
+  ansible.builtin.set_fact:
+      compose_test_project: integration-compose
+      compose_test_definition:
+          services:
+              web:
+                  image: nginx:alpine
+                  container_name: integration-compose-web
+                  ports:
+                      - "127.0.0.1:18080:80"
+
+- name: Apply docker_compose_v2 role (first run, inline definition)
+  ansible.builtin.include_role:
+      name: arillso.container.docker_compose_v2
+  vars:
+      docker_compose_v2_project: "{{ compose_test_project }}"
+      docker_compose_v2_use_file: false
+      docker_compose_v2_config: "{{ compose_test_definition }}"
+      docker_compose_v2_state: present
+
+- name: Verify the compose plugin is available
+  ansible.builtin.command: docker compose version
+  register: compose_version
+  changed_when: false
+
+- name: Display compose plugin version
+  ansible.builtin.debug:
+      var: compose_version.stdout
+
+- name: Gather running containers for the compose project
+  community.docker.docker_container_info:
+      name: integration-compose-web
+  register: compose_container
+
+- name: Assert the compose service container is running
+  ansible.builtin.assert:
+      that:
+          - compose_container.exists
+          - compose_container.container.State.Running
+      fail_msg: "docker_compose_v2 did not start the expected service container"
+      success_msg: "docker_compose_v2 brought the compose project up correctly"
+
+- name: Apply docker_compose_v2 role again (idempotency check)
+  ansible.builtin.include_role:
+      name: arillso.container.docker_compose_v2
+  vars:
+      docker_compose_v2_project: "{{ compose_test_project }}"
+      docker_compose_v2_use_file: false
+      docker_compose_v2_config: "{{ compose_test_definition }}"
+      docker_compose_v2_state: present
+  register: compose_second_run
+
+- name: Tear down the compose project
+  ansible.builtin.include_role:
+      name: arillso.container.docker_compose_v2
+  vars:
+      docker_compose_v2_project: "{{ compose_test_project }}"
+      docker_compose_v2_use_file: false
+      docker_compose_v2_config: "{{ compose_test_definition }}"
+      docker_compose_v2_state: absent
+      docker_compose_v2_remove_volumes: true
+
+- name: Verify the compose service container is gone after teardown
+  community.docker.docker_container_info:
+      name: integration-compose-web
+  register: compose_container_removed
+
+- name: Assert the compose project was removed
+  ansible.builtin.assert:
+      that:
+          - not compose_container_removed.exists
+      fail_msg: "docker_compose_v2 left the service container running after state=absent"
+      success_msg: "docker_compose_v2 tore the compose project down correctly"

--- a/tests/integration/targets/fleet/aliases
+++ b/tests/integration/targets/fleet/aliases
@@ -1,0 +1,3 @@
+destructive
+needs/root
+disabled

--- a/tests/integration/targets/fleet/meta/main.yml
+++ b/tests/integration/targets/fleet/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+    - k3s

--- a/tests/integration/targets/fleet/tasks/main.yml
+++ b/tests/integration/targets/fleet/tasks/main.yml
@@ -32,7 +32,8 @@
             create_namespace: true
             target_namespace: default
             resources:
-                - content: |
+                - name: integration-fleet-cm
+                  content: |
                       apiVersion: v1
                       kind: ConfigMap
                       metadata:
@@ -70,7 +71,8 @@
             create_namespace: false
             target_namespace: default
             resources:
-                - content: |
+                - name: integration-fleet-cm
+                  content: |
                       apiVersion: v1
                       kind: ConfigMap
                       metadata:

--- a/tests/integration/targets/fleet/tasks/main.yml
+++ b/tests/integration/targets/fleet/tasks/main.yml
@@ -1,0 +1,96 @@
+---
+# Integration tests for the fleet role.
+#
+# DISABLED in CI (see aliases): exercising this role end-to-end requires a
+# running K3s cluster with the Rancher Fleet CRDs and controller installed
+# (the Bundle resource is applied with wait_condition type=Ready, which only
+# reconciles once the Fleet controller is present). Plain CI runners and the
+# default ansible-test containers do not ship Fleet, so this target is gated
+# behind `disabled` and the `k3s` dependency. Run it manually against a
+# cluster that has Fleet deployed:
+#
+#     ansible-test integration fleet --allow-disabled
+#
+# The test covers the main Bundle path with inline resources (no Git auth
+# required), verifies the Bundle was created, then tears it down again.
+
+- name: Resolve kubeconfig path for the test cluster
+  ansible.builtin.set_fact:
+      fleet_test_kubeconfig: "{{ fleet_kubeconfig_path | default('/etc/rancher/k3s/k3s.yaml') }}"
+      fleet_test_bundle: integration-fleet-bundle
+      fleet_test_namespace: fleet-default
+
+- name: Apply fleet role with an inline-resource bundle
+  ansible.builtin.include_role:
+      name: arillso.container.fleet
+  vars:
+      fleet_enable_bundles: true
+      fleet_kubeconfig_path: "{{ fleet_test_kubeconfig }}"
+      fleet_bundles:
+          - name: "{{ fleet_test_bundle }}"
+            namespace: "{{ fleet_test_namespace }}"
+            create_namespace: true
+            target_namespace: default
+            resources:
+                - content: |
+                      apiVersion: v1
+                      kind: ConfigMap
+                      metadata:
+                          name: integration-fleet-cm
+                          namespace: default
+                      data:
+                          managed-by: arillso-fleet-integration
+
+- name: Verify the Fleet Bundle exists
+  kubernetes.core.k8s_info:
+      kubeconfig: "{{ fleet_test_kubeconfig }}"
+      api_version: fleet.cattle.io/v1alpha1
+      kind: Bundle
+      name: "{{ fleet_test_bundle }}"
+      namespace: "{{ fleet_test_namespace }}"
+  register: fleet_bundle_info
+
+- name: Assert the Fleet Bundle was created
+  ansible.builtin.assert:
+      that:
+          - fleet_bundle_info.resources | length == 1
+      fail_msg: "Fleet Bundle '{{ fleet_test_bundle }}' was not created"
+      success_msg: "Fleet Bundle '{{ fleet_test_bundle }}' created successfully"
+
+- name: Tear down the Fleet Bundle
+  ansible.builtin.include_role:
+      name: arillso.container.fleet
+  vars:
+      fleet_enable_bundles: true
+      fleet_kubeconfig_path: "{{ fleet_test_kubeconfig }}"
+      fleet_state: absent
+      fleet_bundles:
+          - name: "{{ fleet_test_bundle }}"
+            namespace: "{{ fleet_test_namespace }}"
+            create_namespace: false
+            target_namespace: default
+            resources:
+                - content: |
+                      apiVersion: v1
+                      kind: ConfigMap
+                      metadata:
+                          name: integration-fleet-cm
+                          namespace: default
+                      data:
+                          managed-by: arillso-fleet-integration
+
+- name: Verify the Fleet Bundle is gone after teardown
+  kubernetes.core.k8s_info:
+      kubeconfig: "{{ fleet_test_kubeconfig }}"
+      api_version: fleet.cattle.io/v1alpha1
+      kind: Bundle
+      name: "{{ fleet_test_bundle }}"
+      namespace: "{{ fleet_test_namespace }}"
+  register: fleet_bundle_removed
+
+- name: Assert the Fleet Bundle was removed
+  ansible.builtin.assert:
+      that:
+          - fleet_bundle_removed.resources | length == 0
+      fail_msg: "Fleet Bundle '{{ fleet_test_bundle }}' still present after state=absent"
+      success_msg: "Fleet Bundle '{{ fleet_test_bundle }}' removed successfully"

--- a/tests/integration/targets/tailscale/aliases
+++ b/tests/integration/targets/tailscale/aliases
@@ -1,0 +1,3 @@
+destructive
+needs/root
+disabled

--- a/tests/integration/targets/tailscale/meta/main.yml
+++ b/tests/integration/targets/tailscale/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+    - k3s

--- a/tests/integration/targets/tailscale/tasks/main.yml
+++ b/tests/integration/targets/tailscale/tasks/main.yml
@@ -1,0 +1,104 @@
+---
+# Integration tests for the tailscale role.
+#
+# DISABLED in CI (see aliases). This role does NOT install Tailscale on a host
+# with an auth key; it manages Tailscale Kubernetes resources (ProxyGroups,
+# Ingress/Egress Services) via the tailscale.com/v1alpha1 CRDs. Exercising it
+# end-to-end therefore requires:
+#   * a running K3s cluster (provided via the `k3s` dependency), AND
+#   * the Tailscale Kubernetes operator installed in that cluster, which in
+#     turn needs a Tailscale OAuth client (client id + secret) to register
+#     with the tailnet and to install the ProxyGroup/Connector CRDs.
+#
+# The OAuth client secret is NEVER hardcoded. It is read from the environment
+# (TS_OAUTH_CLIENT_SECRET) and only used to bootstrap the operator; the role
+# itself takes no credentials. CI runners have neither the operator nor a
+# tailnet credential, so this target is gated behind `disabled`. Run manually
+# against a prepared cluster:
+#
+#     TS_OAUTH_CLIENT_ID=... TS_OAUTH_CLIENT_SECRET=... \
+#       ansible-test integration tailscale --allow-disabled
+#
+# The test covers the main ProxyGroup path, verifies the ProxyGroup CR was
+# created, then tears it down again.
+
+- name: Resolve test parameters
+  ansible.builtin.set_fact:
+      tailscale_test_kubeconfig: /etc/rancher/k3s/k3s.yaml
+      tailscale_test_namespace: tailscale
+      tailscale_test_proxygroup: integration-ingress
+      # Credential is read from the environment, never committed. It is only
+      # required to bootstrap the operator (out of scope for this role); the
+      # role under test does not consume it directly.
+      tailscale_test_oauth_secret: "{{ lookup('env', 'TS_OAUTH_CLIENT_SECRET') }}"
+
+- name: Fail early if the Tailscale OAuth credential is missing
+  ansible.builtin.assert:
+      that:
+          - tailscale_test_oauth_secret | length > 0
+      fail_msg: >-
+          TS_OAUTH_CLIENT_SECRET is not set. The Tailscale operator cannot be
+          bootstrapped without it, so the tailscale CRDs will be unavailable.
+          Export the credential before running this target with --allow-disabled.
+      success_msg: "Tailscale OAuth credential present in environment"
+
+- name: Apply tailscale role with a single ingress ProxyGroup
+  ansible.builtin.include_role:
+      name: arillso.container.tailscale
+  vars:
+      tailscale_kubeconfig_path: "{{ tailscale_test_kubeconfig }}"
+      tailscale_state: present
+      tailscale_proxygroups:
+          - name: "{{ tailscale_test_proxygroup }}"
+            namespace: "{{ tailscale_test_namespace }}"
+            type: ingress
+            replicas: 1
+            tags:
+                - "tag:k8s-ingress"
+
+- name: Verify the Tailscale ProxyGroup CR exists
+  kubernetes.core.k8s_info:
+      kubeconfig: "{{ tailscale_test_kubeconfig }}"
+      api_version: tailscale.com/v1alpha1
+      kind: ProxyGroup
+      name: "{{ tailscale_test_proxygroup }}"
+      namespace: "{{ tailscale_test_namespace }}"
+  register: tailscale_proxygroup_info
+
+- name: Assert the ProxyGroup was created
+  ansible.builtin.assert:
+      that:
+          - tailscale_proxygroup_info.resources | length == 1
+          - tailscale_proxygroup_info.resources[0].spec.type == "ingress"
+      fail_msg: "Tailscale ProxyGroup '{{ tailscale_test_proxygroup }}' was not created"
+      success_msg: "Tailscale ProxyGroup '{{ tailscale_test_proxygroup }}' created successfully"
+
+- name: Tear down the Tailscale ProxyGroup
+  ansible.builtin.include_role:
+      name: arillso.container.tailscale
+  vars:
+      tailscale_kubeconfig_path: "{{ tailscale_test_kubeconfig }}"
+      tailscale_state: absent
+      tailscale_proxygroups:
+          - name: "{{ tailscale_test_proxygroup }}"
+            namespace: "{{ tailscale_test_namespace }}"
+            type: ingress
+            replicas: 1
+            tags:
+                - "tag:k8s-ingress"
+
+- name: Verify the ProxyGroup is gone after teardown
+  kubernetes.core.k8s_info:
+      kubeconfig: "{{ tailscale_test_kubeconfig }}"
+      api_version: tailscale.com/v1alpha1
+      kind: ProxyGroup
+      name: "{{ tailscale_test_proxygroup }}"
+      namespace: "{{ tailscale_test_namespace }}"
+  register: tailscale_proxygroup_removed
+
+- name: Assert the ProxyGroup was removed
+  ansible.builtin.assert:
+      that:
+          - tailscale_proxygroup_removed.resources | length == 0
+      fail_msg: "Tailscale ProxyGroup '{{ tailscale_test_proxygroup }}' still present after state=absent"
+      success_msg: "Tailscale ProxyGroup '{{ tailscale_test_proxygroup }}' removed successfully"

--- a/tests/integration/targets/tailscale/tasks/main.yml
+++ b/tests/integration/targets/tailscale/tasks/main.yml
@@ -27,20 +27,12 @@
       tailscale_test_kubeconfig: /etc/rancher/k3s/k3s.yaml
       tailscale_test_namespace: tailscale
       tailscale_test_proxygroup: integration-ingress
-      # Credential is read from the environment, never committed. It is only
-      # required to bootstrap the operator (out of scope for this role); the
-      # role under test does not consume it directly.
-      tailscale_test_oauth_secret: "{{ lookup('env', 'TS_OAUTH_CLIENT_SECRET') }}"
-
-- name: Fail early if the Tailscale OAuth credential is missing
-  ansible.builtin.assert:
-      that:
-          - tailscale_test_oauth_secret | length > 0
-      fail_msg: >-
-          TS_OAUTH_CLIENT_SECRET is not set. The Tailscale operator cannot be
-          bootstrapped without it, so the tailscale CRDs will be unavailable.
-          Export the credential before running this target with --allow-disabled.
-      success_msg: "Tailscale OAuth credential present in environment"
+      # Prerequisite (out of scope for this role, documented in the header):
+      # a running Tailscale operator with the tailscale.com/v1alpha1 CRDs,
+      # bootstrapped from a TS_OAUTH_CLIENT_SECRET. This target only exercises
+      # the role's ProxyGroup management against those CRDs, so the secret is
+      # not consumed here — the target is `disabled` precisely because that
+      # cluster prerequisite cannot be assumed in CI.
 
 - name: Apply tailscale role with a single ingress ProxyGroup
   ansible.builtin.include_role:


### PR DESCRIPTION
## Summary

- Only `docker` and `k3s` had `ansible-test integration` targets. The multi-registry `docker_compose_v2` logic and the Kubernetes integrations (`fleet`, `tailscale`) were untested.
- Adds one target each under `tests/integration/targets/`, modelled on the existing docker/k3s targets (setup → assert → teardown with `state: absent`, `meta/main.yml` for dependency ordering).
- **docker_compose_v2**: `destructive`/`needs/root`/`needs/privileged`, depends on `docker`; rolls out an inline nginx:alpine compose service, asserts running, idempotent re-run, teardown.
- **fleet**: `disabled` (needs a live k3s cluster with Fleet CRDs), depends on `k3s`; applies an inline ConfigMap bundle, asserts via k8s_info, teardown via `fleet_state: absent`.
- **tailscale**: `disabled` (needs k3s + Tailscale operator CRDs + OAuth client); applies a ProxyGroup, OAuth secret read from `TS_OAUTH_CLIENT_SECRET` env — never hardcoded.

## Test plan

- [ ] `ansible-test integration --list-targets` discovers all five (local: ok)
- [ ] yamllint + ansible-lint green (local: 0 failures)
- [ ] `ansible-test integration docker_compose_v2 --allow-destructive --allow-root` on a Docker host
- [ ] fleet/tailscale targets need `--allow-disabled` + a live cluster (+ `TS_OAUTH_*` for tailscale)

> `ansible-test integration` itself not run here (needs Docker registries / k8s / Tailscale creds + root). Only `--list-targets` + lint done locally.