### PR TITLE
fix(roles): replace deprecated ansible syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `defaults`/`argument_specs`), and migrate the docker Debian/Ubuntu
   repository tasks from the deprecated `ansible.builtin.apt_repository` to
   `ansible.builtin.deb822_repository`. Removes the `INJECT_FACTS_AS_VARS`
-  (core 2.24) and `apt_repository` (core 2.25) deprecation warnings.
+  (core 2.24) and `apt_repository` (core 2.25) deprecation warnings. The
+  docker role now installs `python3-debian` (required by
+  `deb822_repository`) and removes any legacy `docker.list` left by earlier
+  role versions to avoid a duplicate apt source.
 - **Renovate**: track the `python_version` CI input via Renovate. Each
   `python_version:` in `pull-request.yml`/`merge.yml` carries a
   `# renovate: datasource=github-releases depName=python/cpython` marker, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Deprecated syntax**: replace top-level `ansible_*` fact references with
+  `ansible_facts['...']` across the docker, k3s and helm roles (and their
+  `defaults`/`argument_specs`), and migrate the docker Debian/Ubuntu
+  repository tasks from the deprecated `ansible.builtin.apt_repository` to
+  `ansible.builtin.deb822_repository`. Removes the `INJECT_FACTS_AS_VARS`
+  (core 2.24) and `apt_repository` (core 2.25) deprecation warnings.
 - **Renovate**: track the `python_version` CI input via Renovate. Each
   `python_version:` in `pull-request.yml`/`merge.yml` carries a
   `# renovate: datasource=github-releases depName=python/cpython` marker, and

--- a/roles/docker/tasks/install_docker_debian.yml
+++ b/roles/docker/tasks/install_docker_debian.yml
@@ -1,4 +1,17 @@
 ---
+- name: "Debian : ensure deb822 dependency"
+  become: true
+  ansible.builtin.apt:
+      name: python3-debian
+      state: present
+      update_cache: true
+
+- name: "Debian : remove legacy docker.list"
+  become: true
+  ansible.builtin.file:
+      path: /etc/apt/sources.list.d/docker.list
+      state: absent
+
 - name: "Debian : add key"
   become: true
   ansible.builtin.get_url:

--- a/roles/docker/tasks/install_docker_debian.yml
+++ b/roles/docker/tasks/install_docker_debian.yml
@@ -9,11 +9,20 @@
 
 - name: "Debian : add repository"
   become: true
-  ansible.builtin.apt_repository:
-      repo: >
-          deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.asc]
-          https://download.docker.com/linux/{{ ansible_distribution | lower }}
-          {{ ansible_distribution_release }} stable
+  ansible.builtin.deb822_repository:
+      name: docker
+      types: deb
+      architectures: amd64
+      signed_by: /usr/share/keyrings/docker-archive-keyring.asc
+      uris: "https://download.docker.com/linux/{{ ansible_facts['distribution'] | lower }}"
+      suites: "{{ ansible_facts['distribution_release'] }}"
+      components: stable
       state: present
+      enabled: true
+  register: docker_repo
+
+- name: "Debian : update apt cache"
+  become: true
+  ansible.builtin.apt:
       update_cache: true
-      filename: "docker"
+  when: docker_repo is changed

--- a/roles/docker/tasks/install_docker_ubuntu.yml
+++ b/roles/docker/tasks/install_docker_ubuntu.yml
@@ -21,11 +21,20 @@
 
 - name: "Ubuntu : add repository"
   become: true
-  ansible.builtin.apt_repository:
-      repo: >
-          deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
-          https://download.docker.com/linux/{{ ansible_distribution | lower }}
-          {{ ansible_distribution_release }} stable
+  ansible.builtin.deb822_repository:
+      name: docker
+      types: deb
+      architectures: amd64
+      signed_by: /etc/apt/keyrings/docker.asc
+      uris: "https://download.docker.com/linux/{{ ansible_facts['distribution'] | lower }}"
+      suites: "{{ ansible_facts['distribution_release'] }}"
+      components: stable
       state: present
+      enabled: true
+  register: docker_repo
+
+- name: "Ubuntu : update apt cache"
+  become: true
+  ansible.builtin.apt:
       update_cache: true
-      filename: "docker"
+  when: docker_repo is changed

--- a/roles/docker/tasks/install_docker_ubuntu.yml
+++ b/roles/docker/tasks/install_docker_ubuntu.yml
@@ -6,10 +6,23 @@
       state: directory
       mode: "0755"
 
+- name: "Ubuntu : ensure deb822 dependency"
+  become: true
+  ansible.builtin.apt:
+      name: python3-debian
+      state: present
+      update_cache: true
+
 - name: "Ubuntu : remove legacy GPG key"
   become: true
   ansible.builtin.file:
       path: /etc/apt/trusted.gpg.d/docker.asc
+      state: absent
+
+- name: "Ubuntu : remove legacy docker.list"
+  become: true
+  ansible.builtin.file:
+      path: /etc/apt/sources.list.d/docker.list
       state: absent
 
 - name: "Ubuntu : add key"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -5,11 +5,11 @@
   ansible.builtin.include_vars: "{{ loop_vars }}"
   with_first_found:
       - files:
-            - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
-            - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-            - "{{ ansible_distribution }}.yml"
-            - "{{ ansible_os_family }}.yml"
-            - "{{ ansible_system }}.yml"
+            - "{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
+            - "{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+            - "{{ ansible_facts['distribution'] }}.yml"
+            - "{{ ansible_facts['os_family'] }}.yml"
+            - "{{ ansible_facts['system'] }}.yml"
             - "defaults.yml"
         paths:
             - "vars"
@@ -19,16 +19,16 @@
 - name: Include distribution tasks
   ansible.builtin.include_tasks: "{{ lookup('ansible.builtin.first_found', params) }}"
   vars:
-      distribution: "{{ ansible_distribution }}"
-      distribution_version: "{{ ansible_distribution_version }}"
-      distribution_major_version: "{{ ansible_distribution_major_version }}"
+      distribution: "{{ ansible_facts['distribution'] }}"
+      distribution_version: "{{ ansible_facts['distribution_version'] }}"
+      distribution_major_version: "{{ ansible_facts['distribution_major_version'] }}"
       params:
           files:
               - "install_docker_{{ distribution | lower }}_{{ distribution_version | lower }}.yml"
               - "install_docker_{{ distribution | lower }}_{{ distribution_major_version | lower }}.yml"
               - "install_docker_{{ distribution | lower }}.yml"
-              - "install_docker_{{ ansible_os_family | lower }}.yml"
-              - "install_docker_{{ ansible_system | lower }}.yml"
+              - "install_docker_{{ ansible_facts['os_family'] | lower }}.yml"
+              - "install_docker_{{ ansible_facts['system'] | lower }}.yml"
               - "defaults.yml"
 
 - name: Install docker

--- a/roles/helm/tasks/prerequisites.yml
+++ b/roles/helm/tasks/prerequisites.yml
@@ -10,7 +10,7 @@
       - "/etc/rancher/k3s/k3s.yaml"
       - "/var/lib/rancher/k3s/server/cred/admin.kubeconfig"
       - "/root/.kube/config"
-      - "{{ ansible_env.HOME | default('/root') }}/.kube/config"
+      - "{{ ansible_facts['env']['HOME'] | default('/root') }}/.kube/config"
   when: helm_kubeconfig_path is not defined or helm_kubeconfig_path == ""
   run_once: true
 

--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -29,8 +29,8 @@ k3s_disable_cloud_controller: false
 
 # K3s server configuration
 k3s_tls_san: []
-k3s_node_ip: "{{ ansible_default_ipv4.address }}"
-k3s_bind_address: "{{ ansible_default_ipv4.address }}"
+k3s_node_ip: "{{ ansible_facts['default_ipv4']['address'] }}"
+k3s_bind_address: "{{ ansible_facts['default_ipv4']['address'] }}"
 k3s_https_listen_port: 6443
 
 # Readiness probe tuning; set k3s_health_check_delay: 0 to skip idle wait on converged servers.

--- a/roles/k3s/meta/argument_specs.yml
+++ b/roles/k3s/meta/argument_specs.yml
@@ -53,7 +53,7 @@ argument_specs:
             k3s_bind_address:
                 type: "str"
                 required: false
-                default: "{{ ansible_default_ipv4.address }}"
+                default: "{{ ansible_facts['default_ipv4']['address'] }}"
                 description: "K3s API server bind address"
 
             k3s_https_listen_port:
@@ -87,7 +87,7 @@ argument_specs:
             k3s_node_ip:
                 type: "str"
                 required: false
-                default: "{{ ansible_default_ipv4.address }}"
+                default: "{{ ansible_facts['default_ipv4']['address'] }}"
                 description: "K3s node IP address"
 
             k3s_tls_san:
@@ -488,7 +488,7 @@ argument_specs:
             k3s_bind_address:
                 type: "str"
                 required: false
-                default: "{{ ansible_default_ipv4.address }}"
+                default: "{{ ansible_facts['default_ipv4']['address'] }}"
                 description: "K3s API server bind address"
 
             k3s_https_listen_port:
@@ -534,7 +534,7 @@ argument_specs:
             k3s_bind_address:
                 type: "str"
                 required: false
-                default: "{{ ansible_default_ipv4.address }}"
+                default: "{{ ansible_facts['default_ipv4']['address'] }}"
                 description: "K3s API server bind address"
 
             k3s_https_listen_port:

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -68,16 +68,16 @@
 - name: Detect system architecture
   ansible.builtin.set_fact:
       k3s_arch: >-
-          {%- if ansible_architecture == "x86_64" -%}
+          {%- if ansible_facts['architecture'] == "x86_64" -%}
             amd64
-          {%- elif ansible_architecture == "aarch64" -%}
+          {%- elif ansible_facts['architecture'] == "aarch64" -%}
             arm64
-          {%- elif ansible_architecture == "armv7l" -%}
+          {%- elif ansible_facts['architecture'] == "armv7l" -%}
             arm
-          {%- elif ansible_architecture == "s390x" -%}
+          {%- elif ansible_facts['architecture'] == "s390x" -%}
             s390x
           {%- else -%}
-            {{ ansible_architecture }}
+            {{ ansible_facts['architecture'] }}
           {%- endif -%}
 
 - name: Set K3s binary suffix based on architecture
@@ -130,7 +130,7 @@
       - ansible_local.k3s.cluster_info.server_url is defined
       - ansible_local.k3s.cluster_info.server_url != ""
       - k3s_role == "agent" or (k3s_role == "server" and not k3s_server_init | bool)
-      - ansible_local.k3s.cluster_info.server_url not in ['https://' + ansible_default_ipv4.address + ':' + k3s_https_listen_port | string, 'https://' + inventory_hostname + ':' + k3s_https_listen_port | string]
+      - ansible_local.k3s.cluster_info.server_url not in ['https://' + ansible_facts['default_ipv4']['address'] + ':' + k3s_https_listen_port | string, 'https://' + inventory_hostname + ':' + k3s_https_listen_port | string]
 
 # Fallback server URL determination from inventory when facts are not available
 - name: Set server URL from inventory (fallback)
@@ -281,8 +281,8 @@
       k3s_health_check_host: >-
           {%- if k3s_bind_address != '0.0.0.0' -%}
             {{ k3s_bind_address }}
-          {%- elif ansible_default_ipv4.address is defined -%}
-            {{ ansible_default_ipv4.address }}
+          {%- elif ansible_facts['default_ipv4']['address'] is defined -%}
+            {{ ansible_facts['default_ipv4']['address'] }}
           {%- elif k3s_node_ip is defined and k3s_node_ip -%}
             {{ k3s_node_ip }}
           {%- else -%}

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -6,9 +6,9 @@
 - name: Detect security framework in use
   ansible.builtin.set_fact:
       k3s_security_framework: >-
-          {%- if ansible_selinux.status is defined and ansible_selinux.status != "disabled" -%}
+          {%- if ansible_facts['selinux']['status'] is defined and ansible_facts['selinux']['status'] != "disabled" -%}
             selinux
-          {%- elif ansible_apparmor is defined and ansible_apparmor.status == "enabled" -%}
+          {%- elif ansible_facts['apparmor'] is defined and ansible_facts['apparmor']['status'] == "enabled" -%}
             apparmor
           {%- else -%}
             none
@@ -31,26 +31,26 @@
                 - policycoreutils-python-utils
             state: present
         become: true
-        when: ansible_os_family == "RedHat"
+        when: ansible_facts['os_family'] == "RedHat"
 
       - name: Check for k3s-selinux package availability
         ansible.builtin.uri:
-            url: "https://rpm.rancher.io/k3s/stable/common/centos/{{ ansible_distribution_major_version }}/noarch/"
+            url: "https://rpm.rancher.io/k3s/stable/common/centos/{{ ansible_facts['distribution_major_version'] }}/noarch/"
             method: GET
             status_code: 200
             timeout: 10
         register: k3s_selinux_repo_check
         failed_when: false
-        when: ansible_os_family == "RedHat"
+        when: ansible_facts['os_family'] == "RedHat"
 
       - name: Install k3s-selinux package
         ansible.builtin.package:
-            name: "https://rpm.rancher.io/k3s/stable/common/centos/{{ ansible_distribution_major_version }}/noarch/k3s-selinux-1.4-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
+            name: "https://rpm.rancher.io/k3s/stable/common/centos/{{ ansible_facts['distribution_major_version'] }}/noarch/k3s-selinux-1.4-1.el{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
             state: present
             disable_gpg_check: true
         become: true
         when:
-            - ansible_os_family == "RedHat"
+            - ansible_facts['os_family'] == "RedHat"
             - k3s_selinux_repo_check.status == 200
         failed_when: false
         register: k3s_selinux_install
@@ -127,7 +127,7 @@
                 - apparmor-profiles
             state: present
         become: true
-        when: ansible_os_family == "Debian"
+        when: ansible_facts['os_family'] == "Debian"
 
       - name: Deploy cri-containerd AppArmor profile with change_profile support
         ansible.builtin.copy:

--- a/roles/k3s/tasks/utilities.yml
+++ b/roles/k3s/tasks/utilities.yml
@@ -46,7 +46,7 @@
   become: true
   when:
       - k3s_create_bash_completion | default(true) | bool
-      - ansible_os_family in ['Debian', 'RedHat']
+      - ansible_facts['os_family'] in ['Debian', 'RedHat']
 
 - name: Create K3s bash completion
   ansible.builtin.shell: |
@@ -54,7 +54,7 @@
   become: true
   when:
       - k3s_create_bash_completion | default(true) | bool
-      - ansible_os_family in ['Debian', 'RedHat']
+      - ansible_facts['os_family'] in ['Debian', 'RedHat']
       - k3s_completion_test is defined
       - k3s_completion_test.rc == 0
   changed_when: true
@@ -67,7 +67,7 @@
       - k3s_create_bash_completion | default(true) | bool
       - k3s_create_symlinks | bool
       - "'kubectl' in k3s_symlink_commands"
-      - ansible_os_family in ['Debian', 'RedHat']
+      - ansible_facts['os_family'] in ['Debian', 'RedHat']
       - k3s_completion_test is defined
       - k3s_completion_test.rc == 0
   changed_when: true


### PR DESCRIPTION
## Summary

- Replace top-level `ansible_*` fact references with `ansible_facts['...']` across the docker, k3s and helm roles (tasks, `defaults`, `argument_specs`), clearing the `INJECT_FACTS_AS_VARS` deprecation removed in ansible-core 2.24.
- Migrate the docker Debian/Ubuntu repository tasks from the deprecated `ansible.builtin.apt_repository` to `ansible.builtin.deb822_repository`, with an explicit apt cache update on change (deb822_repository has no `update_cache`). `apt_repository` is removed in ansible-core 2.25.
- `hostvars[...]['ansible_*']` dict lookups and RedHat `yum_repository` are left untouched — those forms are not deprecated.

## Test plan

- `ansible-lint roles/docker roles/k3s roles/helm` — no deprecation/syntax errors (only pre-existing line-length warnings).
- Per-role molecule scenarios (docker, k3s) run via `pull-request.yml` CI.