### PR TITLE
ci(security): rename to nightly-security.yml and run daily

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -1,11 +1,11 @@
 ---
-name: Weekly Security Scan
+name: Nightly Security Scan
 run-name: |
     Security Scan by @${{ github.actor }}
 
 on:
     schedule:
-        - cron: "0 2 * * 1"
+        - cron: "0 2 * * *" # Daily 02:00 UTC (public repo — Actions minutes are free)
     workflow_dispatch:
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ ansible.container/
 ├── .github/workflows/
 │   ├── pull-request.yml    # Lint, tests, per-role molecule, secret scan, Claude review
 │   ├── merge.yml           # CI + secret scan on push to main
-│   ├── weekly-security.yml # Scheduled weekly secret scan
+│   ├── nightly-security.yml # Scheduled daily secret scan
 │   └── tag.yml             # Galaxy publishing (triggered by tag)
 ├── roles/
 │   ├── docker/
@@ -126,7 +126,7 @@ Event-focused workflows calling reusables from `arillso/.github`:
 
 - `pull-request.yml` - Lint, unit/integration tests, per-role molecule, secret scan, and Claude review on PRs
 - `merge.yml` - Same CI plus secret scan on push to `main`
-- `weekly-security.yml` - Scheduled weekly secret scan
+- `nightly-security.yml` - Scheduled daily secret scan
 - `tag.yml` - Publishes to Ansible Galaxy on tag push (e.g. `0.0.8`)
 
 ### Release Process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,9 +79,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `release`, and pin the reusable workflow to `@2026-06-18`.
 - `.python-version` `3.14` → `3.13` (org-wide target — `3.14` is rejected by
   `ansible-test`, which supports at most `3.13`).
-- Rename `nightly-security.yml` → `weekly-security.yml` (`name: Weekly Security
-Scan`) to match the cadence-honest org workflow-naming convention; the cron
-  was already weekly (`0 2 * * 1`).
+- Security scan runs as `nightly-security.yml` (`name: Nightly Security Scan`)
+  on a daily cron (`0 2 * * *`). Per the repo-standard visibility rule, public
+  repos run the scan daily (free Actions minutes); private repos run it weekly.
 - `LICENSE` copyright `2025` → `2023-2026` (org range `FIRST-CURRENT`,
   consistent with the README).
 - **Role metadata**: drop EOL Ubuntu `focal` (and Debian `buster` where present)


### PR DESCRIPTION
## Summary

Renames `weekly-security.yml` → `nightly-security.yml` ("Nightly Security Scan") and switches to a **daily** cron `0 2 * * *`.

## Why

Per the arillso/sbaerlocher repo-standard visibility rule: **public** repos get free GitHub Actions minutes → security scan runs daily; **private** repos run it weekly to save paid minutes. `ansible.container` is public → daily. (Standard note updated 2026-06-27.)

## Test plan

- [ ] CI green