### PR TITLE
fix(tasks): mask credential-handling tasks with no_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Secret masking**: tasks that read, render or transport credentials ran
+  without `no_log: true`, so the values were printed with `-v` or in the task
+  result. The k3s cluster join token (`slurp` + `set_fact` in
+  `roles/k3s/tasks/main.yml`), the k3s config and registries templates, the
+  Fleet GitRepo auth secret and the Fleet `ClusterRegistrationToken` lookup,
+  and the `docker_login` registry login are now all masked. The `k3s_token`
+  and `docker_login_password` options in `argument_specs.yml` carry `no_log`
+  as well, matching the already-masked `k3s_etcd_s3_*` keys.
 - **fleet argument_specs**: the main entry point used six separate `<<:` merge
   keys in one mapping, which `ruamel.yaml` (used by ansible-lint) rejects as
   duplicate keys. Consolidated into a single YAML 1.1 list-form merge

--- a/roles/docker_login/meta/argument_specs.yml
+++ b/roles/docker_login/meta/argument_specs.yml
@@ -48,6 +48,7 @@ argument_specs:
 
             docker_login_password:
                 type: str
+                no_log: true
                 description:
                     - The plaintext password for the registry account.
                 default: ""

--- a/roles/docker_login/tasks/main.yml
+++ b/roles/docker_login/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Login to Docker registry
   become: true
+  no_log: true
   community.docker.docker_login:
       api_version: "{{ docker_login_api_version }}"
       ca_cert: "{{ docker_login_ca_cert | default(omit) }}"

--- a/roles/fleet/tasks/auth.yml
+++ b/roles/fleet/tasks/auth.yml
@@ -18,6 +18,7 @@
           stringData: "{{ {'username': item.git_username, 'password': item.git_token} if item.git_token is defined and item.git_username is defined else {'ssh-privatekey': item.git_ssh_private_key, 'known_hosts': item.git_known_hosts} if item.git_ssh_private_key is defined and item.git_known_hosts is defined else {'ssh-privatekey': item.git_ssh_private_key} if item.git_ssh_private_key is defined else {} }}"
           type: "{{ 'kubernetes.io/basic-auth' if item.git_token is defined and item.git_username is defined else 'kubernetes.io/ssh-auth' if item.git_ssh_private_key is defined else '' }}"
       state: present
+  no_log: true
   loop: "{{ fleet_gitrepos | default([]) }}"
   when:
       - fleet_gitrepos | length > 0

--- a/roles/fleet/tasks/registration_tokens.yml
+++ b/roles/fleet/tasks/registration_tokens.yml
@@ -51,6 +51,7 @@
       - fleet_registration_tokens | length > 0
       - fleet_state == "present"
       - not ansible_check_mode
+  no_log: true
   register: fleet_registration_token_secrets
   tags:
       - fleet

--- a/roles/k3s/meta/argument_specs.yml
+++ b/roles/k3s/meta/argument_specs.yml
@@ -47,6 +47,7 @@ argument_specs:
             k3s_token:
                 type: "str"
                 required: false
+                no_log: true
                 default: ""
                 description: "K3s cluster token for authentication"
 
@@ -529,6 +530,7 @@ argument_specs:
             k3s_token:
                 type: "str"
                 required: true
+                no_log: true
                 description: "K3s cluster token"
 
             k3s_bind_address:
@@ -568,6 +570,7 @@ argument_specs:
             k3s_token:
                 type: "str"
                 required: true
+                no_log: true
                 description: "K3s cluster token"
 
             k3s_node_labels:

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -107,6 +107,7 @@
       src: "{{ k3s_token_file }}"
   register: cluster_token
   failed_when: false
+  no_log: true
   when:
       - k3s_token == ""
       - not (k3s_role == "server" and k3s_server_init | bool)
@@ -115,6 +116,7 @@
 - name: Set token from first server
   ansible.builtin.set_fact:
       k3s_token: "{{ cluster_token.content | b64decode | trim }}"
+  no_log: true
   when:
       - k3s_token == ""
       - cluster_token is defined
@@ -239,6 +241,7 @@
       owner: root
       group: root
   become: true
+  no_log: true
   notify: Restart k3s
 
 - name: Create k3s registries config
@@ -249,6 +252,7 @@
       owner: root
       group: root
   become: true
+  no_log: true
   when: k3s_private_registries | length > 0
   notify: Restart k3s
 


### PR DESCRIPTION
## Summary

- Add `no_log: true` to every task that reads, renders or transports a credential: the k3s join token (`slurp` + `set_fact`), the k3s config and registries templates, the Fleet GitRepo auth secret, the Fleet `ClusterRegistrationToken` lookup and the `docker_login` registry login. Without it the values were printed in the task result and readable with `-v`.
- Mark `k3s_token` (all three entry points) and `docker_login_password` as `no_log` in `argument_specs.yml`, matching the already-masked `k3s_etcd_s3_access_key` / `k3s_etcd_s3_secret_key`.
- No logic change — masking only.

## Test plan

- [ ] CI green (ansible-lint, yamllint, unit and integration tests, per-role molecule)
- [x] `yamllint .` clean (only pre-existing line-length warnings)
- [x] `pytest tests/unit/` — 13 passed
- [x] `gitleaks` clean on the diff
- [ ] Verify a k3s run with `-v` no longer prints the join token