### PR TITLE
test(k3s): add idempotence to molecule test sequence

### DIFF
--- a/roles/k3s/molecule/default/molecule.yml
+++ b/roles/k3s/molecule/default/molecule.yml
@@ -58,6 +58,7 @@ scenario:
         - create
         - prepare
         - converge
+        - idempotence
         - verify
         - cleanup
         - destroy


### PR DESCRIPTION
## Summary

- Add `idempotence` to the `test_sequence` of the k3s Molecule default scenario, placed after `converge` to match the docker scenario.
- The scenario already converges successfully; only the idempotence proof was missing, so the role gained no coverage from a second run before this.
- `side_effect` is deliberately not adopted: the k3s scenario directory ships no `side_effect.yml`.

## Test plan

- [ ] `molecule-k3s` job in `pull-request.yml` runs green with `idempotence` in the sequence (QEMU boot plus two k3s converge runs, expect >10 min).
- [ ] `yamllint roles/k3s/molecule/default/molecule.yml` clean (verified locally).
- [ ] `ansible-lint` covered by CI only — the tool is not installed on the machine this branch was prepared on, so the local pre-commit hook for it was skipped.