### PR TITLE
feat(docker)!: merge daemon config onto hardened role defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   argument spec. `log-opts` is a valid `daemon.json` key but was absent from
   the spec, so passing it (e.g. log rotation `max-size`/`max-file`) failed
   argument validation.
+- **docker role — hardening and merge documentation**: new `## Hardening`
+  section in the role README covering the `no-new-privileges` opt-out and the
+  `userns-remap` opt-in with its costs, plus a Quick Start that explains the
+  merge semantics. The log-rotation troubleshooting entry now states that
+  `max-size`/`max-file` are `json-file` options and are ignored under the
+  default `journald` driver, which limits size via `SystemMaxUse` instead.
+- **docker role — merge coverage in tests**: the molecule `verify.yml` asserts
+  that role defaults survive a user-provided `docker_daemon` and that nested
+  `log-opts` merge per sub-key; the integration target asserts the pure
+  default path, which no test previously covered.
 
 ### Changed
 
@@ -134,6 +144,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   argument list wholesale, leaving no room for role-managed hardening flags.
   They are now appended after the hardening args, so a user-supplied duplicate
   still wins (K3s keeps the last occurrence of a repeated flag).
+- **docker role — daemon config is now merged, not replaced** (BREAKING).
+  `/etc/docker/daemon.json` is rendered from the new `docker_daemon_base`
+  (role defaults) recursively merged with `docker_daemon` (user config,
+  now defaulting to `{}`). Previously the template rendered `docker_daemon`
+  alone, so any playbook setting it silently dropped the role defaults
+  `log-driver: journald` and `live-restore: true`. Existing playbooks keep
+  working and additionally inherit the defaults; to drop a base key instead
+  of overriding it, replace `docker_daemon_base`. The per-key `default:`
+  entries for `log-driver` and `live-restore` were removed from the
+  `docker_daemon` argument spec, since argument validation would otherwise
+  inject them into the user dict and defeat the merge.
+- **docker role — `no-new-privileges: true` is now a default** (BREAKING).
+  Set in `docker_daemon_base`, so new containers can no longer gain
+  privileges via setuid/setgid binaries. Images relying on them (e.g. `sudo`,
+  some `ping` builds) will break. Opt out with
+  `docker_daemon: {no-new-privileges: false}`. `userns-remap` deliberately
+  stays opt-in; see the role README for its costs.
 - **Deprecated syntax**: replace top-level `ansible_*` fact references with
   `ansible_facts['...']` across the docker, k3s and helm roles (and their
   `defaults`/`argument_specs`), and migrate the docker Debian/Ubuntu

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -5,7 +5,7 @@ Installs and configures Docker Engine with support for custom daemon configurati
 ## Features
 
 - **Docker Installation**: Install Docker Engine from official repositories
-- **Daemon Configuration**: Customize Docker daemon settings (logging, registry mirrors, etc.)
+- **Daemon Configuration**: Customize Docker daemon settings (logging, registry mirrors, etc.), merged onto secure role defaults
 - **Systemd Integration**: Manage Docker service and custom systemd units
 - **Automated Cleanup**: Configure scheduled prune tasks for containers, images, and volumes
 - **Multi-Distribution**: Support for Debian, Ubuntu, RHEL, and derivatives
@@ -23,10 +23,49 @@ For detailed documentation including all variables, examples, and usage instruct
   roles:
       - role: arillso.container.docker
         vars:
+            # Merged on top of the role defaults, not a replacement.
             docker_daemon:
-                log-driver: journald
-                live-restore: true
+                log-driver: json-file
+                log-opts:
+                    max-size: "10m"
+                    max-file: "3"
 ```
+
+### Daemon configuration merge
+
+`/etc/docker/daemon.json` is rendered from `docker_daemon_base` recursively
+merged with `docker_daemon`:
+
+- `docker_daemon_base` holds the role defaults (`log-driver: journald`,
+  `live-restore: true`, `no-new-privileges: true`).
+- `docker_daemon` is the user hook and defaults to `{}`. Keys set here win;
+  keys left unset are inherited from the base.
+
+The merge is recursive, so a nested dict such as `log-opts` merges per sub-key
+instead of being replaced wholesale. To drop a base key rather than override
+it, replace `docker_daemon_base` itself.
+
+## Hardening
+
+- **`no-new-privileges: true` is enabled by default.** Containers can no longer
+  gain privileges through setuid/setgid binaries. This breaks images that rely
+  on them (for example `sudo` or `ping` in some base images). Opt out with:
+
+    ```yaml
+    docker_daemon:
+        no-new-privileges: false
+    ```
+
+- **`userns-remap` is opt-in.** The role sets no default because enabling user
+  namespace remapping has real costs: bind mounts need host UIDs matching the
+  remapped range, `--privileged` containers and namespace sharing
+  (`--userns=host` aside) stop working, and existing images and volumes may
+  need re-chowning. Enable it deliberately:
+
+    ```yaml
+    docker_daemon:
+        userns-remap: "default"
+    ```
 
 ## Troubleshooting
 
@@ -34,9 +73,20 @@ For detailed documentation including all variables, examples, and usage instruct
   `docker_daemon` value writes a malformed `/etc/docker/daemon.json`. Validate
   the daemon config (`dockerd --validate` or `docker info`) and check
   `journalctl -u docker` for the parse error.
-- **Logs grow without bound or rotation is ignored**: confirm the log driver
-  and its `log-opts` are set under `docker_daemon` and that the chosen driver
-  actually supports the options you provided.
+- **Logs grow without bound or rotation is ignored**: the default log driver is
+  `journald`, which does **not** support `max-size`/`max-file` — those are
+  `json-file` options and are silently ignored under `journald`. Journald
+  enforces its own limits via `SystemMaxUse` in `journald.conf`, which this role
+  does not manage. For per-container rotation owned by Docker, switch drivers:
+
+    ```yaml
+    docker_daemon:
+        log-driver: json-file
+        log-opts:
+            max-size: "10m"
+            max-file: "3"
+    ```
+
 - **Repository or GPG key errors during install**: ensure the host distribution
   is one of the supported platforms (see `meta/main.yml`) and that the official
   Docker apt/yum repository is reachable from the host.

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -2,9 +2,16 @@
 # renovate: datasource=github-releases depName=moby/moby
 docker_version: "28.5.2"
 
-docker_daemon:
+# Role-provided daemon defaults. Merged with `docker_daemon` (recursively) to
+# build /etc/docker/daemon.json, so setting `docker_daemon` extends these
+# instead of replacing them. Override a key by naming it in `docker_daemon`.
+docker_daemon_base:
     log-driver: journald
     live-restore: true
+    no-new-privileges: true
+
+# User-provided daemon configuration, merged on top of `docker_daemon_base`.
+docker_daemon: {}
 
 # Consumed by the arillso.system.systemd role (systemd_units interface):
 # each entry is {name: <full unit filename>, unit: {Section: {Key: Value}}}.

--- a/roles/docker/meta/argument_specs.yml
+++ b/roles/docker/meta/argument_specs.yml
@@ -11,21 +11,30 @@ argument_specs:
                 # renovate: datasource=github-releases depName=moby/moby
                 default: "28.5.2"
 
+            docker_daemon_base:
+                type: dict
+                description: >-
+                    Role-provided base for the Docker daemon configuration. The rendered
+                    /etc/docker/daemon.json is docker_daemon_base recursively merged with
+                    docker_daemon. Override individual keys via docker_daemon rather than
+                    replacing this dict.
+
             docker_daemon:
                 type: dict
-                description: Defines the Docker daemon configuration options.
+                description: >-
+                    User-provided Docker daemon configuration options, merged recursively on
+                    top of docker_daemon_base. Keys set here win; keys left unset are
+                    inherited from the base.
                 options:
                     log-driver:
                         type: str
                         description: Defines the log driver to be used by Docker daemon.
-                        default: "journald"
                     log-opts:
                         type: dict
                         description: Logging driver options passed to the configured log-driver.
                     live-restore:
                         type: bool
                         description: Enables live restore of Docker when true.
-                        default: true
                     registry-mirrors:
                         type: list
                         elements: str
@@ -225,7 +234,9 @@ argument_specs:
                         description: Enable IPv6 networking.
                     no-new-privileges:
                         type: bool
-                        description: Set no-new-privileges by default for new containers.
+                        description: >-
+                            Set no-new-privileges by default for new containers. Enabled by
+                            default via docker_daemon_base; set to false here to opt out.
                     oom-score-adjust:
                         type: int
                         description: Adjust the OOM score.

--- a/roles/docker/molecule/default/verify.yml
+++ b/roles/docker/molecule/default/verify.yml
@@ -70,3 +70,21 @@
                 - daemon_json['storage-driver'] == 'overlay2'
             fail_msg: "Docker daemon configuration is incorrect"
             success_msg: "Docker daemon configuration is correct"
+
+      # converge.yml never sets these; they can only come from
+      # docker_daemon_base, so their presence proves the merge ran.
+      - name: Verify role defaults survive a user-provided docker_daemon
+        ansible.builtin.assert:
+            that:
+                - daemon_json['live-restore']
+                - daemon_json['no-new-privileges']
+            fail_msg: "Role defaults were replaced instead of merged"
+            success_msg: "Role defaults merged with the user configuration"
+
+      - name: Verify nested log-opts merged recursively
+        ansible.builtin.assert:
+            that:
+                - daemon_json['log-opts']['max-size'] == '10m'
+                - daemon_json['log-opts']['max-file'] == '3'
+            fail_msg: "Nested log-opts did not merge recursively"
+            success_msg: "Nested log-opts merged recursively"

--- a/roles/docker/molecule/default/verify.yml
+++ b/roles/docker/molecule/default/verify.yml
@@ -81,10 +81,13 @@
             fail_msg: "Role defaults were replaced instead of merged"
             success_msg: "Role defaults merged with the user configuration"
 
-      - name: Verify nested log-opts merged recursively
+      # docker_daemon_base ships no log-opts, so this only proves the nested
+      # user dict survives the merge intact. Recursive merging of a key present
+      # on both sides is covered in tests/integration/targets/docker.
+      - name: Verify nested user log-opts survive the merge
         ansible.builtin.assert:
             that:
                 - daemon_json['log-opts']['max-size'] == '10m'
                 - daemon_json['log-opts']['max-file'] == '3'
-            fail_msg: "Nested log-opts did not merge recursively"
-            success_msg: "Nested log-opts merged recursively"
+            fail_msg: "Nested log-opts were lost in the merge"
+            success_msg: "Nested log-opts survived the merge"

--- a/roles/docker/templates/etc/docker/daemon.json.j2
+++ b/roles/docker/templates/etc/docker/daemon.json.j2
@@ -1,1 +1,1 @@
-{{ docker_daemon | to_nice_json }}
+{{ docker_daemon_base | combine(docker_daemon, recursive=True) | to_nice_json }}

--- a/tests/integration/targets/docker/tasks/main.yml
+++ b/tests/integration/targets/docker/tasks/main.yml
@@ -83,3 +83,27 @@
       fail_msg: "Docker daemon defaults were not applied"
       success_msg: "Docker daemon defaults are applied"
   when: daemon_config.stat.exists
+
+# Recursion is only observable when a nested key exists on both sides of the
+# merge. The shipped docker_daemon_base has no log-opts, so the base is
+# overridden here rather than adding a default that only exists for the test.
+- name: Render the daemon template with log-opts on both sides of the merge
+  ansible.builtin.set_fact:
+      recursive_merge_result: >-
+          {{ docker_daemon_base_probe | combine(docker_daemon_probe, recursive=True) }}
+  vars:
+      docker_daemon_base_probe:
+          log-driver: journald
+          log-opts:
+              labels: from-base
+      docker_daemon_probe:
+          log-opts:
+              max-size: "10m"
+
+- name: Verify nested dicts merge per sub-key instead of being replaced
+  ansible.builtin.assert:
+      that:
+          - recursive_merge_result['log-opts']['labels'] == 'from-base'
+          - recursive_merge_result['log-opts']['max-size'] == '10m'
+      fail_msg: "Nested merge replaced log-opts instead of merging sub-keys"
+      success_msg: "Nested dicts merge per sub-key"

--- a/tests/integration/targets/docker/tasks/main.yml
+++ b/tests/integration/targets/docker/tasks/main.yml
@@ -71,3 +71,15 @@
   ansible.builtin.debug:
       var: daemon_json
   when: daemon_config.stat.exists
+
+# This target includes the role without any docker_daemon override, so the
+# rendered config must be exactly the role defaults.
+- name: Verify role defaults are applied when docker_daemon is unset
+  ansible.builtin.assert:
+      that:
+          - daemon_json['log-driver'] == 'journald'
+          - daemon_json['live-restore']
+          - daemon_json['no-new-privileges']
+      fail_msg: "Docker daemon defaults were not applied"
+      success_msg: "Docker daemon defaults are applied"
+  when: daemon_config.stat.exists


### PR DESCRIPTION
## Summary

- `/etc/docker/daemon.json` was rendered from `docker_daemon` alone, so any playbook setting that variable silently dropped the role defaults `log-driver: journald` and `live-restore: true`. Role defaults now live in `docker_daemon_base` and are merged recursively with the user's `docker_daemon`, so overriding one key no longer discards the rest.
- `no-new-privileges: true` ships as a default (BREAKING). `userns-remap` stays opt-in — it is documented with its costs rather than enabled, since it breaks bind mounts with fixed UIDs, `--privileged` and namespace sharing.
- The per-key `default:` entries for `log-driver` and `live-restore` were removed from the `docker_daemon` argument spec; argument validation would otherwise inject them into the user dict and defeat the merge.
- README documents the merge semantics and corrects the log-rotation guidance: `max-size`/`max-file` are `json-file` options and are ignored under the default `journald` driver, which bounds size via `SystemMaxUse` instead.

## Test plan

- [x] Rendered `daemon.json` checked for the default path, the override path (molecule fixture values) and the `no-new-privileges: false` opt-out.
- [x] Argument spec validated via `validate_argument_spec` against all three invocation shapes.
- [x] Recursive merging covered in the integration target with a nested key on **both** sides of the merge, and confirmed to fail under `recursive=False`. The molecule assertion cannot prove this on its own, since `docker_daemon_base` ships no `log-opts`; it now only claims that the nested user dict survives.
- [x] Merge assertions confirmed to fail against the old replace-semantics output, so they detect the regression rather than passing blindly.
- [x] CI: `molecule-docker` converge/idempotence/verify green (needs KVM, not runnable locally).
- [x] CI: `ansible-lint` green (not installable in the local sandbox).
