### PR TITLE
fix(molecule): pin the docker_compose_v2 converge image by digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **docker_compose_v2 molecule idempotence**: the `default` scenario failed on
-  the launch task with `Idempotence test failed`. A container that fails to
-  start is not surfaced by the module — it reports the `up` as changed and
-  continues, and the idempotence run then recreates the stopped container,
-  which reads as a non-idempotent task rather than as the start error it is.
-  Converge now asserts the container is running, so the actual cause fails the
-  converge step with a readable message.
 - **Secret masking**: tasks that read, render or transport credentials ran
   without `no_log: true`, so the values were printed with `-v` or in the task
   result. The k3s cluster join token (`slurp` + `set_fact` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **docker_compose_v2 molecule idempotence**: the `default` scenario failed on
+  the launch task with `Idempotence test failed`. `nginx:alpine` is an OCI image
+  index with 16 manifests, and compose stores the resolved image ID in the
+  container's `com.docker.compose.image` label. Once the tag resolved to a
+  different ID than the stored one, compose recreated the container on every
+  run — the config hash still matched on both sides, so only the image label
+  differed. The converge image is now pinned by digest.
 - **Secret masking**: tasks that read, render or transport credentials ran
   without `no_log: true`, so the values were printed with `-v` or in the task
   result. The k3s cluster join token (`slurp` + `set_fact` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **docker_compose_v2 molecule idempotence**: the `default` scenario failed on
+  the launch task with `Idempotence test failed`. A container that fails to
+  start is not surfaced by the module — it reports the `up` as changed and
+  continues, and the idempotence run then recreates the stopped container,
+  which reads as a non-idempotent task rather than as the start error it is.
+  Converge now asserts the container is running, so the actual cause fails the
+  converge step with a readable message.
 - **Secret masking**: tasks that read, render or transport credentials ran
   without `no_log: true`, so the values were printed with `-v` or in the task
   result. The k3s cluster join token (`slurp` + `set_fact` in

--- a/roles/docker_compose_v2/molecule/default/converge.yml
+++ b/roles/docker_compose_v2/molecule/default/converge.yml
@@ -22,3 +22,25 @@
       - name: Include docker_compose_v2 role
         ansible.builtin.include_role:
             name: arillso.container.docker_compose_v2
+
+      # A container that fails to start is not reported by the role: the
+      # module reports the `up` itself as changed and moves on. The next
+      # `up` then recreates the stopped container, which surfaces as an
+      # idempotence failure on the launch task instead of as the start
+      # error it actually is. Assert the container is running here so the
+      # real cause fails the converge step with a readable message.
+      - name: Read the state of the compose containers
+        ansible.builtin.command:
+            cmd: docker compose ps --format '{{ "{{" }}.Name{{ "}}" }} {{ "{{" }}.State{{ "}}" }}'
+            chdir: "/etc/docker/compose/molecule"
+        register: docker_compose_v2_state_out
+        changed_when: false
+
+      - name: Verify the compose container is running
+        ansible.builtin.assert:
+            that:
+                - "'running' in docker_compose_v2_state_out.stdout"
+            fail_msg: >-
+                compose container is not running:
+                {{ docker_compose_v2_state_out.stdout | default('no output') }}
+            success_msg: "compose container is running"

--- a/roles/docker_compose_v2/molecule/default/converge.yml
+++ b/roles/docker_compose_v2/molecule/default/converge.yml
@@ -23,27 +23,45 @@
         ansible.builtin.include_role:
             name: arillso.container.docker_compose_v2
 
-      # Diagnostic: the launch task reports `changed` on the idempotence
-      # run while the container keeps running and nothing is recreated.
-      # The module derives `changed` from the compose events on stderr, so
-      # print the raw state and events here to identify which event the
-      # module counts. Remove once the cause is known.
-      - name: Read the state of the compose containers
+      # Diagnostic: compose emits `Recreate` on the idempotence run even
+      # though the container is running, which is what makes the module
+      # report `changed`. Compose recreates when the container's stored
+      # config hash differs from the one derived from the compose file, so
+      # read that hash plus the compose version here. Read-only on purpose:
+      # running `up` in this playbook would consume the recreate and mask
+      # the failure. Remove once the cause is known.
+      - name: Read the compose and docker versions
         ansible.builtin.command:
-            cmd: docker compose ps --all --format '{{ "{{" }}.Name{{ "}}" }} {{ "{{" }}.State{{ "}}" }} {{ "{{" }}.Image{{ "}}" }}'
-            chdir: "/etc/docker/compose/molecule"
-        register: docker_compose_v2_state_out
+            cmd: docker compose version --short
+        register: docker_compose_v2_version_probe
         changed_when: false
 
-      - name: Re-run the compose up the module performs
+      - name: Read the stored config hash of the compose container
         ansible.builtin.command:
-            cmd: docker compose up --detach --no-color --quiet-pull
-            chdir: "/etc/docker/compose/molecule"
-        register: docker_compose_v2_up_out
+            cmd: >-
+                docker inspect molecule-web-1
+                --format '{{ "{{" }}index .Config.Labels "com.docker.compose.config-hash"{{ "}}" }}'
+        register: docker_compose_v2_hash_stored
         changed_when: false
+        failed_when: false
 
-      - name: Show the container state and the compose events
+      - name: Read the config hash compose derives from the file
+        ansible.builtin.command:
+            cmd: docker compose config --hash=web
+            chdir: "/etc/docker/compose/molecule"
+        register: docker_compose_v2_hash_expected
+        changed_when: false
+        failed_when: false
+
+      - name: Read the rendered compose file
+        ansible.builtin.slurp:
+            src: /etc/docker/compose/molecule/docker-compose.yml
+        register: docker_compose_v2_file_probe
+
+      - name: Show the hashes and the rendered file
         ansible.builtin.debug:
             msg:
-                - "state: {{ docker_compose_v2_state_out.stdout_lines }}"
-                - "up stderr: {{ docker_compose_v2_up_out.stderr_lines }}"
+                - "compose version: {{ docker_compose_v2_version_probe.stdout }}"
+                - "stored hash: {{ docker_compose_v2_hash_stored.stdout | default('n/a') }}"
+                - "expected hash: {{ docker_compose_v2_hash_expected.stdout | default('n/a') }}"
+                - "file: {{ docker_compose_v2_file_probe.content | b64decode }}"

--- a/roles/docker_compose_v2/molecule/default/converge.yml
+++ b/roles/docker_compose_v2/molecule/default/converge.yml
@@ -53,6 +53,23 @@
         changed_when: false
         failed_when: false
 
+      - name: Read the compose labels stored on the container
+        ansible.builtin.command:
+            cmd: >-
+                docker inspect molecule-web-1
+                --format '{{ "{{" }}json .Config.Labels{{ "}}" }}'
+        register: docker_compose_v2_labels_stored
+        changed_when: false
+        failed_when: false
+
+      - name: Ask compose whether it would recreate the container
+        ansible.builtin.command:
+            cmd: docker compose --dry-run up --detach --no-color --quiet-pull
+            chdir: "/etc/docker/compose/molecule"
+        register: docker_compose_v2_dry_run
+        changed_when: false
+        failed_when: false
+
       - name: Read the rendered compose file
         ansible.builtin.slurp:
             src: /etc/docker/compose/molecule/docker-compose.yml
@@ -62,6 +79,9 @@
         ansible.builtin.debug:
             msg:
                 - "compose version: {{ docker_compose_v2_version_probe.stdout }}"
+                - "labels: {{ docker_compose_v2_labels_stored.stdout | default('n/a') }}"
+                - "dry-run stdout: {{ docker_compose_v2_dry_run.stdout_lines | default([]) }}"
+                - "dry-run stderr: {{ docker_compose_v2_dry_run.stderr_lines | default([]) }}"
                 - "stored hash: {{ docker_compose_v2_hash_stored.stdout | default('n/a') }}"
                 - "expected hash: {{ docker_compose_v2_hash_expected.stdout | default('n/a') }}"
                 - "file: {{ docker_compose_v2_file_probe.content | b64decode }}"

--- a/roles/docker_compose_v2/molecule/default/converge.yml
+++ b/roles/docker_compose_v2/molecule/default/converge.yml
@@ -15,73 +15,17 @@
       docker_compose_v2_config:
           services:
               web:
-                  image: nginx:alpine
+                  # Pin the image by digest. `nginx:alpine` is an OCI image
+                  # index with 16 manifests, and compose stores the resolved
+                  # image ID in the `com.docker.compose.image` label. When the
+                  # tag resolves to a different ID than the stored one, compose
+                  # recreates the container even though the config hash still
+                  # matches, and the idempotence step fails on the launch task.
+                  # renovate: datasource=docker depName=nginx versioning=docker
+                  image: nginx:alpine@sha256:1d40e3eb3bf4f138de1d67193f2aa5309fcaf343eb5ffadbf5e9439de1eb1ebb
                   ports:
                       - "8080:80"
   tasks:
       - name: Include docker_compose_v2 role
         ansible.builtin.include_role:
             name: arillso.container.docker_compose_v2
-
-      # Diagnostic: compose emits `Recreate` on the idempotence run even
-      # though the container is running, which is what makes the module
-      # report `changed`. Compose recreates when the container's stored
-      # config hash differs from the one derived from the compose file, so
-      # read that hash plus the compose version here. Read-only on purpose:
-      # running `up` in this playbook would consume the recreate and mask
-      # the failure. Remove once the cause is known.
-      - name: Read the compose and docker versions
-        ansible.builtin.command:
-            cmd: docker compose version --short
-        register: docker_compose_v2_version_probe
-        changed_when: false
-
-      - name: Read the stored config hash of the compose container
-        ansible.builtin.command:
-            cmd: >-
-                docker inspect molecule-web-1
-                --format '{{ "{{" }}index .Config.Labels "com.docker.compose.config-hash"{{ "}}" }}'
-        register: docker_compose_v2_hash_stored
-        changed_when: false
-        failed_when: false
-
-      - name: Read the config hash compose derives from the file
-        ansible.builtin.command:
-            cmd: docker compose config --hash=web
-            chdir: "/etc/docker/compose/molecule"
-        register: docker_compose_v2_hash_expected
-        changed_when: false
-        failed_when: false
-
-      - name: Read the compose labels stored on the container
-        ansible.builtin.command:
-            cmd: >-
-                docker inspect molecule-web-1
-                --format '{{ "{{" }}json .Config.Labels{{ "}}" }}'
-        register: docker_compose_v2_labels_stored
-        changed_when: false
-        failed_when: false
-
-      - name: Ask compose whether it would recreate the container
-        ansible.builtin.command:
-            cmd: docker compose --dry-run up --detach --no-color --quiet-pull
-            chdir: "/etc/docker/compose/molecule"
-        register: docker_compose_v2_dry_run
-        changed_when: false
-        failed_when: false
-
-      - name: Read the rendered compose file
-        ansible.builtin.slurp:
-            src: /etc/docker/compose/molecule/docker-compose.yml
-        register: docker_compose_v2_file_probe
-
-      - name: Show the hashes and the rendered file
-        ansible.builtin.debug:
-            msg:
-                - "compose version: {{ docker_compose_v2_version_probe.stdout }}"
-                - "labels: {{ docker_compose_v2_labels_stored.stdout | default('n/a') }}"
-                - "dry-run stdout: {{ docker_compose_v2_dry_run.stdout_lines | default([]) }}"
-                - "dry-run stderr: {{ docker_compose_v2_dry_run.stderr_lines | default([]) }}"
-                - "stored hash: {{ docker_compose_v2_hash_stored.stdout | default('n/a') }}"
-                - "expected hash: {{ docker_compose_v2_hash_expected.stdout | default('n/a') }}"
-                - "file: {{ docker_compose_v2_file_probe.content | b64decode }}"

--- a/roles/docker_compose_v2/molecule/default/converge.yml
+++ b/roles/docker_compose_v2/molecule/default/converge.yml
@@ -23,24 +23,27 @@
         ansible.builtin.include_role:
             name: arillso.container.docker_compose_v2
 
-      # A container that fails to start is not reported by the role: the
-      # module reports the `up` itself as changed and moves on. The next
-      # `up` then recreates the stopped container, which surfaces as an
-      # idempotence failure on the launch task instead of as the start
-      # error it actually is. Assert the container is running here so the
-      # real cause fails the converge step with a readable message.
+      # Diagnostic: the launch task reports `changed` on the idempotence
+      # run while the container keeps running and nothing is recreated.
+      # The module derives `changed` from the compose events on stderr, so
+      # print the raw state and events here to identify which event the
+      # module counts. Remove once the cause is known.
       - name: Read the state of the compose containers
         ansible.builtin.command:
-            cmd: docker compose ps --format '{{ "{{" }}.Name{{ "}}" }} {{ "{{" }}.State{{ "}}" }}'
+            cmd: docker compose ps --all --format '{{ "{{" }}.Name{{ "}}" }} {{ "{{" }}.State{{ "}}" }} {{ "{{" }}.Image{{ "}}" }}'
             chdir: "/etc/docker/compose/molecule"
         register: docker_compose_v2_state_out
         changed_when: false
 
-      - name: Verify the compose container is running
-        ansible.builtin.assert:
-            that:
-                - "'running' in docker_compose_v2_state_out.stdout"
-            fail_msg: >-
-                compose container is not running:
-                {{ docker_compose_v2_state_out.stdout | default('no output') }}
-            success_msg: "compose container is running"
+      - name: Re-run the compose up the module performs
+        ansible.builtin.command:
+            cmd: docker compose up --detach --no-color --quiet-pull
+            chdir: "/etc/docker/compose/molecule"
+        register: docker_compose_v2_up_out
+        changed_when: false
+
+      - name: Show the container state and the compose events
+        ansible.builtin.debug:
+            msg:
+                - "state: {{ docker_compose_v2_state_out.stdout_lines }}"
+                - "up stderr: {{ docker_compose_v2_up_out.stderr_lines }}"


### PR DESCRIPTION
## Summary

- The `molecule-docker-compose-v2` job has been failing on every branch since
  2026-08-05 with `Idempotence test failed` on the launch task. It is not
  caused by any role change: the same commit passed on 2026-07-27, and the job
  fails equally on branches that touch no role code (`renovate/all-non-major`).
- Root cause is the floating `nginx:alpine` tag. It is an OCI image index with
  16 manifests, and compose stores the resolved image ID in the container's
  `com.docker.compose.image` label. Once the tag resolved to a different ID
  than the stored one, compose recreated the container on every run. The
  `Recreate` event is in `DOCKER_STATUS_WORKING`, so the module reports
  `changed` and the idempotence step fails.
- The converge image is now pinned by digest, which keeps the resolved image
  ID stable across runs.

Established from CI rather than assumed — the probe showed the config hash
matching on both sides (`0df62ea0…93bc`), compose 5.4.0 on both, the container
running, and `--dry-run up` still reporting `Recreate`. The only differing
attribute was the image label.

## Test plan

- [ ] `molecule-docker-compose-v2` passes
- [ ] All other `molecule-*` jobs unaffected
- [ ] CI green, local lints green (ansible-lint production profile passed)
