### PR TITLE
refactor(lint): rename yamllint config and raise line-length limit

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,7 +3,7 @@ extends: default
 
 rules:
     line-length:
-        max: 160
+        max: 500
         level: warning
 
     comments:
@@ -17,7 +17,7 @@ rules:
         check-multi-line-strings: false
 
     truthy:
-        allowed-values: ['true', 'false']
+        allowed-values: ["true", "false"]
         check-keys: false
 
     brackets:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ git checkout -b fix/issue-description
 - Use 4 spaces for indentation (no tabs)
 - Use lowercase with underscores for variable names
 - Prefix role variables with the role name
-- Keep lines under 160 characters
+- Keep lines under 500 characters
 - Require `---` document start
 
 ### Python
@@ -61,7 +61,7 @@ git checkout -b fix/issue-description
 
 ### Role Structure
 
-```
+```text
 roles/ROLE_NAME/
 ├── defaults/
 │   └── main.yml              # User-configurable variables
@@ -116,7 +116,7 @@ make build
 
 Write clear, descriptive commit messages:
 
-```
+```text
 Brief summary (50 chars or less)
 
 - Detailed description with bullet points

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,7 +21,7 @@ pre-commit:
         yamllint:
             glob: "*.{yml,yaml}"
             exclude: "(^\\.ansible/)"
-            run: yamllint -c .yamllint {staged_files}
+            run: yamllint -c .yamllint.yml {staged_files}
         markdownlint:
             glob: "*.md"
             exclude: "(^\\.ansible/)"


### PR DESCRIPTION
## Summary

- Rename `.yamllint` to `.yamllint.yml` — the published CI template hardcodes `config_file: .yamllint.yml`, so the filename is functional rather than cosmetic.
- Raise `line-length.max` from 160 to 500; the collection has real lines above 160 (e.g. `roles/fleet/tasks/auth.yml`, `roles/k3s/tasks/main.yml`) that pass today only because the rule sits at `level: warning`.
- Pull along the references: `lefthook.yml` (`-c .yamllint.yml`) and the 160-char note in `CONTRIBUTING.md`. `Makefile` needs no change — `yamllint .` resolves the config by name.
- Two fixes the rename made mandatory: `.yamllint.yml` now falls into the prettier glob (quote style), and staging `CONTRIBUTING.md` surfaced two pre-existing MD040 violations.

## Test plan

- [ ] `yamllint .` passes
- [ ] lefthook pre-commit passes (gitleaks, yamllint, markdownlint, prettier)
- [ ] CI green