### PR TITLE
fix(k3s): keep a discovered token out of the server config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not exist yet, so the role initialises the cluster and `k3s_token` stays empty
   — the rendered config carries no `token`. From the second run on, the token
   file exists, the role reads it back and writes it into the config, which
-  changes the file and notifies `Restart k3s`. A server keeps its token in
-  `server/node-token` and does not need it in `config.yaml`, so a token
-  discovered from the cluster is now left out of the server config. Agents still
-  receive the token, since they need it to join.
+  changes the file and notifies `Restart k3s`. A token read from the node's own
+  `server/node-token` is redundant in `config.yaml` and is now left out of the
+  server config. A token fetched from another host stays in place, so secondary
+  servers and agents can still join.
 - **docker_compose_v2 molecule idempotence**: the `default` scenario failed on
   the launch task with `Idempotence test failed`. `nginx:alpine` is an OCI image
   index with 16 manifests, and compose stores the resolved image ID in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **k3s config drift on re-runs**: a server rewrote `config.yaml` and restarted
+  k3s on every run after the first. On the initial run the cluster database does
+  not exist yet, so the role initialises the cluster and `k3s_token` stays empty
+  — the rendered config carries no `token`. From the second run on, the token
+  file exists, the role reads it back and writes it into the config, which
+  changes the file and notifies `Restart k3s`. A server keeps its token in
+  `server/node-token` and does not need it in `config.yaml`, so a token
+  discovered from the cluster is now left out of the server config. Agents still
+  receive the token, since they need it to join.
 - **docker_compose_v2 molecule idempotence**: the `default` scenario failed on
   the launch task with `Idempotence test failed`. `nginx:alpine` is an OCI image
   index with 16 manifests, and compose stores the resolved image ID in the

--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -45,6 +45,7 @@ k3s_config_dir: "/etc/rancher/k3s"
 # K3s token management
 k3s_token: ""
 k3s_token_file: "{{ k3s_data_dir }}/server/node-token"
+k3s_token_discovered: false
 
 # K3s server URL
 k3s_server_url: ""

--- a/roles/k3s/meta/argument_specs.yml
+++ b/roles/k3s/meta/argument_specs.yml
@@ -51,6 +51,18 @@ argument_specs:
                 default: ""
                 description: "K3s cluster token for authentication"
 
+            k3s_token_discovered:
+                type: "bool"
+                required: false
+                default: false
+                description:
+                    - Set by the role when the token was read back from the cluster
+                      instead of being supplied by the caller. A server keeps its
+                      token in the node-token file and does not need it in
+                      config.yaml, so a discovered token is left out of the server
+                      config to keep the file stable across runs. Not intended to be
+                      set manually.
+
             k3s_bind_address:
                 type: "str"
                 required: false

--- a/roles/k3s/meta/argument_specs.yml
+++ b/roles/k3s/meta/argument_specs.yml
@@ -56,12 +56,12 @@ argument_specs:
                 required: false
                 default: false
                 description:
-                    - Set by the role when the token was read back from the cluster
-                      instead of being supplied by the caller. A server keeps its
-                      token in the node-token file and does not need it in
-                      config.yaml, so a discovered token is left out of the server
-                      config to keep the file stable across runs. Not intended to be
-                      set manually.
+                    - Set by the role when the token was read from this node's own
+                      node-token file. Such a token is redundant in config.yaml and
+                      is left out of the server config, which keeps the file stable
+                      across runs. A token fetched from another host is a join
+                      credential and is always written. Not intended to be set
+                      manually.
 
             k3s_bind_address:
                 type: "str"

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -102,6 +102,10 @@
       - always
 
 # Token management - simple approach: first server generates, others retrieve
+- name: Determine the host that holds the cluster token
+  ansible.builtin.set_fact:
+      k3s_token_source: "{{ ansible_local.k3s.inventory.controllers[0] if ansible_local.k3s.inventory.controllers | length > 0 else ansible_local.k3s.inventory.servers[0] if ansible_local.k3s.inventory.servers | length > 0 else inventory_hostname }}"
+
 - name: Retrieve token from first server (if not cluster init)
   ansible.builtin.slurp:
       src: "{{ k3s_token_file }}"
@@ -111,19 +115,18 @@
   when:
       - k3s_token == ""
       - not (k3s_role == "server" and k3s_server_init | bool)
-  delegate_to: "{{ ansible_local.k3s.inventory.controllers[0] if ansible_local.k3s.inventory.controllers | length > 0 else ansible_local.k3s.inventory.servers[0] if ansible_local.k3s.inventory.servers | length > 0 else inventory_hostname }}"
+  delegate_to: "{{ k3s_token_source }}"
 
 - name: Set token from first server
   ansible.builtin.set_fact:
       k3s_token: "{{ cluster_token.content | b64decode | trim }}"
-      # Records that the token was read back from the cluster rather than
-      # supplied by the caller. A server keeps its token in
-      # `server/node-token` and does not need it in config.yaml, so writing
-      # a discovered token there would only rewrite the file once the
-      # cluster exists — changing the config and restarting k3s on every
-      # subsequent run. Agents still need it to join, so they write it
-      # regardless of origin.
-      k3s_token_discovered: true
+      # True only when the token came from this node's own node-token file.
+      # Such a token is redundant in config.yaml — it is absent on the first
+      # run and present on every later one, which would rewrite the file and
+      # restart k3s each time. A token fetched from another host is a join
+      # credential and must be written, otherwise a secondary server or an
+      # agent can never authenticate against the cluster.
+      k3s_token_discovered: "{{ k3s_token_source == inventory_hostname }}"
   no_log: true
   when:
       - k3s_token == ""

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -116,6 +116,14 @@
 - name: Set token from first server
   ansible.builtin.set_fact:
       k3s_token: "{{ cluster_token.content | b64decode | trim }}"
+      # Records that the token was read back from the cluster rather than
+      # supplied by the caller. A server keeps its token in
+      # `server/node-token` and does not need it in config.yaml, so writing
+      # a discovered token there would only rewrite the file once the
+      # cluster exists — changing the config and restarting k3s on every
+      # subsequent run. Agents still need it to join, so they write it
+      # regardless of origin.
+      k3s_token_discovered: true
   no_log: true
   when:
       - k3s_token == ""

--- a/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
+++ b/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
@@ -5,7 +5,11 @@
 {%- set k3s_config = {} -%}
 
 {#- === SECURITY CONFIGURATION (Highest Priority) === -#}
-{%- if k3s_token is defined and k3s_token -%}
+{#- Only a caller-supplied token belongs here. A token read back from the
+    cluster's own `server/node-token` is absent on the first run and present
+    on every later one, which would rewrite config.yaml and restart k3s on
+    each subsequent run. -#}
+{%- if k3s_token is defined and k3s_token and not k3s_token_discovered | default(false) | bool -%}
 {%-   set _ = k3s_config.update({'token': k3s_token}) -%}
 {%- endif -%}
 

--- a/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
+++ b/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
@@ -5,10 +5,11 @@
 {%- set k3s_config = {} -%}
 
 {#- === SECURITY CONFIGURATION (Highest Priority) === -#}
-{#- Only a caller-supplied token belongs here. A token read back from the
-    cluster's own `server/node-token` is absent on the first run and present
-    on every later one, which would rewrite config.yaml and restart k3s on
-    each subsequent run. -#}
+{#- A token read from this node's own node-token file is redundant here: it
+    is absent on the first run and present on every later one, which would
+    rewrite config.yaml and restart k3s each time. A token fetched from
+    another host is a join credential and must be kept, otherwise a
+    secondary server cannot authenticate against the existing cluster. -#}
 {%- if k3s_token is defined and k3s_token and not k3s_token_discovered | default(false) | bool -%}
 {%-   set _ = k3s_config.update({'token': k3s_token}) -%}
 {%- endif -%}


### PR DESCRIPTION
## Summary

- A k3s server rewrote `config.yaml` and restarted k3s on **every run after the
  first**. This affects real deployments, not just tests: any server that is
  re-run picks up an unnecessary service restart.
- On the initial run the cluster database does not exist, so `should_init` is
  true, the role initialises the cluster and `k3s_token` stays empty — the
  rendered config carries no `token`. From the second run on, the database
  exists, `should_init` flips to false, the role reads the token back from
  `server/node-token` and writes it into the config. The file changes and
  `Restart k3s` fires.
- The fix keys on the token's **origin**, not on whether it was discovered. The
  role records the host the token is read from (`k3s_token_source`); a token
  that came from the node's own file is redundant in `config.yaml` and is left
  out. A token fetched from another host is a join credential and is always
  written, so secondary servers and agents still authenticate.

Origin is the right discriminator because `k3s_server_init` cannot tell the two
apart: on a re-run of the first server the database already exists, so
`should_init` is false — the same value a secondary server sees.

| case | token in config |
| --- | --- |
| init server, run 1 (file absent) | no |
| init server, re-run (own file) | no |
| secondary server join (from srv1) | yes |
| secondary server re-run (from srv1) | yes |
| single node, no inventory (self) | no |
| caller-supplied token | yes |

Found via #142, which adds `idempotence` to the k3s molecule sequence and
surfaces this as four non-idempotent tasks (`Create k3s config file` and
`Flush handlers to apply service restarts`, once per platform). The CI log
confirms the mechanism: `Token Exists: False` on converge, `True` on the
idempotence run.

## Test plan

- [ ] `molecule-k3s` passes once #142 is merged (this PR does not enable
      `idempotence` itself)
- [ ] A server run twice in a row leaves `config.yaml` unchanged and does not
      restart k3s
- [ ] A secondary server with an auto-discovered token still joins — the
      molecule scenario is single-server and does not cover this
- [ ] CI green
