### PR TITLE
ci: add codeql scan to nightly security workflow

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -14,9 +14,15 @@ concurrency:
 
 permissions:
     contents: read
+    security-events: write
     actions: read
     pull-requests: read
 
 jobs:
+    codeql:
+        uses: arillso/.github/.github/workflows/security-codeql.yml@2026-06-18
+        with:
+            language: python
+
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-06-18


### PR DESCRIPTION
## Summary

- The nightly security scan ran secret detection only, so the Python filter plugin in `plugins/filter/` was never statically analysed.
- Hooks the `security-codeql.yml@2026-06-18` reusable workflow into `nightly-security.yml`, matching how `go.ansible` wires it up.
- Passes `language: python` explicitly (the reusable workflow defaults to `go`) and adds the `security-events: write` permission the SARIF upload requires.

## Test plan

- [ ] `actionlint`, `yamllint` and `prettier` pass on the changed workflow
- [ ] CI green
- [ ] Nightly run (or manual `workflow_dispatch`) shows the `codeql` job analysing Python and uploading results to the Security tab