### PR TITLE
refactor(roles): migrate remaining top-level facts to ansible_facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,7 +169,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (core 2.24) and `apt_repository` (core 2.25) deprecation warnings. The
   docker role now installs `python3-debian` (required by
   `deb822_repository`) and removes any legacy `docker.list` left by earlier
-  role versions to avoid a duplicate apt source.
+  role versions to avoid a duplicate apt source. A follow-up pass covers the
+  references the first migration missed: the `hostvars[...]['ansible_*']`
+  lookups in `install_docker_redhat.yml` and the k3s server-URL fallbacks,
+  `ansible_local.k3s` → `ansible_facts['ansible_local']['k3s']` on the k3s
+  cluster-init path and in the agent config template, plus
+  `ansible_swaptotal_mb` and the molecule/integration references. Custom facts
+  keep their `ansible_local` key inside `ansible_facts`, unlike the built-in
+  facts that drop the `ansible_` prefix there.
 - **Renovate**: track the `python_version` CI input via Renovate. Each
   `python_version:` in `pull-request.yml`/`merge.yml` carries a
   `# renovate: datasource=github-releases depName=python/cpython` marker, and

--- a/roles/docker/tasks/install_docker_redhat.yml
+++ b/roles/docker/tasks/install_docker_redhat.yml
@@ -11,69 +11,69 @@
   with_items:
       - name: "docker-ce-stable"
         description: "Docker CE Stable - $basearch"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/$basearch/stable'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/$basearch/stable'
         enabled: 1
         gpgkey: "https://download.docker.com/linux/centos/gpg"
       - name: "docker-ce-stable-debuginfo"
         description: "Docker CE Stable - Debuginfo $basearch"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/debug-$basearch/stable'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/debug-$basearch/stable'
         enabled: 0
         gpgkey: "https://download.docker.com/linux/centos/gpg"
       - name: "docker-ce-stable-source"
         description: "Docker CE Stable - Sources"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/source/stable'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/source/stable'
         enabled: 0
         gpgkey: "https://download.docker.com/linux/centos/gpg"
       - name: "docker-ce-edge"
         description: "Docker CE Edge - $basearch"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/$basearch/edge'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/$basearch/edge'
         enabled: 0
         gpgkey: "https://download.docker.com/linux/centos/gpg"
       - name: "docker-ce-edge-debuginfo"
         description: "Docker CE Edge - Debuginfo $basearch"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/debug-$basearch/edge'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/debug-$basearch/edge'
         enabled: 0
         gpgcheck: 1
         gpgkey: "https://download.docker.com/linux/centos/gpg"
       - name: "docker-ce-edge-source"
         description: "Docker CE Edge - Sources"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/source/edge'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/source/edge'
         enabled: 0
         gpgcheck: 1
         gpgkey: "https://download.docker.com/linux/centos/gpg"
       - name: "docker-ce-test"
         description: "Docker CE Test - $basearch"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/$basearch/test'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/$basearch/test'
         enabled: 0
         gpgcheck: 1
         gpgkey: "https://download.docker.com/linux/centos/gpg"
       - name: "docker-ce-test-debuginfo"
         description: "Docker CE Test - Debuginfo $basearch"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/debug-$basearch/test'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/debug-$basearch/test'
         enabled: 0
         gpgcheck: 1
         gpgkey: "https://download.docker.com/linux/centos/gpg"
       - name: "docker-ce-test-source"
         description: "Docker CE Test - Sources"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/source/test'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/source/test'
         enabled: 0
         gpgcheck: 1
         gpgkey: "https://download.docker.com/linux/centos/gpg"
       - name: "docker-ce-nightly"
         description: "Docker CE Nightly - $basearch"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/$basearch/nightly'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/$basearch/nightly'
         enabled: 0
         gpgcheck: 1
         gpgkey: "https://download.docker.com/linux/centos/gpg"
       - name: "docker-ce-nightly-debuginfo"
         description: "Docker CE Nightly - Debuginfo $basearch"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/debug-$basearch/nightly'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/debug-$basearch/nightly'
         enabled: 0
         gpgcheck: 1
         gpgkey: "https://download.docker.com/linux/centos/gpg"
       - name: "docker-ce-nightly-source"
         description: "Docker CE Nightly - Sources"
-        baseurl: 'https://download.docker.com/linux/centos/{{ hostvars[inventory_hostname]["ansible_distribution_major_version"] }}/source/nightly'
+        baseurl: 'https://download.docker.com/linux/centos/{{ ansible_facts["distribution_major_version"] }}/source/nightly'
         enabled: 0
         gpgcheck: 1
         gpgkey: "https://download.docker.com/linux/centos/gpg"

--- a/roles/k3s/molecule/default/converge.yml
+++ b/roles/k3s/molecule/default/converge.yml
@@ -21,7 +21,7 @@
             name: curl
             state: present
             update_cache: true
-        when: ansible_os_family == "Debian"
+        when: ansible_facts['os_family'] == "Debian"
 
   tasks:
       - name: Include k3s role

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -30,7 +30,7 @@
 # Simplified server initialization logic using facts
 - name: Determine server initialization from facts
   ansible.builtin.set_fact:
-      k3s_server_init: "{{ ansible_local.k3s.cluster_info.should_init | bool }}"
+      k3s_server_init: "{{ ansible_facts['ansible_local']['k3s'].cluster_info.should_init | bool }}"
   when:
       - k3s_role == 'server'
       - not k3s_server_init | default(false) | bool # Only auto-determine if not explicitly set
@@ -42,15 +42,15 @@
           - Role: {{ k3s_role }}
           - Server Init: {{ k3s_server_init | default(false) }}
           - Node: {{ inventory_hostname }}
-          - Node Type: {{ ansible_local.k3s.node.type }}
-          - Cluster Initialized: {{ ansible_local.k3s.cluster.initialized }}
-          - Server Responsive: {{ ansible_local.k3s.cluster.server_responsive }}
-          - First Server: {{ ansible_local.k3s.cluster.first_server }}
-          - Binary Installed: {{ ansible_local.k3s.service.binary_installed }}
-          - Service Active: {{ ansible_local.k3s.service.service_active }}
-          - Token Exists: {{ ansible_local.k3s.cluster.token_exists }}
-          - Cluster Server URL: {{ ansible_local.k3s.cluster_info.server_url }}
-          {% if ansible_local.k3s._fallback_mode | default(false) %}
+          - Node Type: {{ ansible_facts['ansible_local']['k3s'].node.type }}
+          - Cluster Initialized: {{ ansible_facts['ansible_local']['k3s'].cluster.initialized }}
+          - Server Responsive: {{ ansible_facts['ansible_local']['k3s'].cluster.server_responsive }}
+          - First Server: {{ ansible_facts['ansible_local']['k3s'].cluster.first_server }}
+          - Binary Installed: {{ ansible_facts['ansible_local']['k3s'].service.binary_installed }}
+          - Service Active: {{ ansible_facts['ansible_local']['k3s'].service.service_active }}
+          - Token Exists: {{ ansible_facts['ansible_local']['k3s'].cluster.token_exists }}
+          - Cluster Server URL: {{ ansible_facts['ansible_local']['k3s'].cluster_info.server_url }}
+          {% if ansible_facts['ansible_local']['k3s']._fallback_mode | default(false) %}
           - [FALLBACK MODE] Facts collected via fallback mechanism
           {% endif %}
 
@@ -61,7 +61,7 @@
           K3s Agent Auto-Discovery Results:
           - Server URL: {{ k3s_server_url | default('NOT SET') }}
           - Token Status: {{ 'AVAILABLE' if k3s_token | default('') != '' else 'NOT AVAILABLE' }}
-          - Source: {{ 'Facts' if ansible_local.k3s.cluster_info.server_url is defined and k3s_server_url == ansible_local.k3s.cluster_info.server_url else 'Inventory Fallback' }}
+          - Source: {{ 'Facts' if ansible_facts['ansible_local']['k3s'].cluster_info.server_url is defined and k3s_server_url == ansible_facts['ansible_local']['k3s'].cluster_info.server_url else 'Inventory Fallback' }}
   when: k3s_role == "agent"
 
 # Architecture detection for K3s binary download
@@ -104,7 +104,14 @@
 # Token management - simple approach: first server generates, others retrieve
 - name: Determine the host that holds the cluster token
   ansible.builtin.set_fact:
-      k3s_token_source: "{{ ansible_local.k3s.inventory.controllers[0] if ansible_local.k3s.inventory.controllers | length > 0 else ansible_local.k3s.inventory.servers[0] if ansible_local.k3s.inventory.servers | length > 0 else inventory_hostname }}"
+      k3s_token_source: >-
+          {{
+          ansible_facts['ansible_local']['k3s'].inventory.controllers[0]
+          if ansible_facts['ansible_local']['k3s'].inventory.controllers | length > 0
+          else ansible_facts['ansible_local']['k3s'].inventory.servers[0]
+          if ansible_facts['ansible_local']['k3s'].inventory.servers | length > 0
+          else inventory_hostname
+          }}
 
 - name: Retrieve token from first server (if not cluster init)
   ansible.builtin.slurp:
@@ -137,18 +144,24 @@
 # Server URL determination using facts with fallback logic
 - name: Set server URL from facts
   ansible.builtin.set_fact:
-      k3s_server_url: "{{ ansible_local.k3s.cluster_info.server_url }}"
+      k3s_server_url: "{{ ansible_facts['ansible_local']['k3s'].cluster_info.server_url }}"
   when:
       - k3s_server_url == ""
-      - ansible_local.k3s.cluster_info.server_url is defined
-      - ansible_local.k3s.cluster_info.server_url != ""
+      - ansible_facts['ansible_local']['k3s'].cluster_info.server_url is defined
+      - ansible_facts['ansible_local']['k3s'].cluster_info.server_url != ""
       - k3s_role == "agent" or (k3s_role == "server" and not k3s_server_init | bool)
-      - ansible_local.k3s.cluster_info.server_url not in ['https://' + ansible_facts['default_ipv4']['address'] + ':' + k3s_https_listen_port | string, 'https://' + inventory_hostname + ':' + k3s_https_listen_port | string]
+      - >-
+          ansible_facts['ansible_local']['k3s'].cluster_info.server_url not in [
+          'https://' + ansible_facts['default_ipv4']['address'] + ':' + k3s_https_listen_port | string,
+          'https://' + inventory_hostname + ':' + k3s_https_listen_port | string
+          ]
 
 # Fallback server URL determination from inventory when facts are not available
 - name: Set server URL from inventory (fallback)
   ansible.builtin.set_fact:
-      k3s_server_url: "https://{{ hostvars[groups['k3s_controllers'][0]]['ansible_default_ipv4']['address'] | default(groups['k3s_controllers'][0]) }}:{{ k3s_https_listen_port }}"
+      k3s_server_url: >-
+          https://{{ hostvars[groups['k3s_controllers'][0]]['ansible_facts']['default_ipv4']['address']
+          | default(groups['k3s_controllers'][0]) }}:{{ k3s_https_listen_port }}
   when:
       - k3s_server_url == ""
       - k3s_role == "agent"
@@ -157,7 +170,9 @@
 
 - name: Set server URL from k3s_servers inventory (fallback)
   ansible.builtin.set_fact:
-      k3s_server_url: "https://{{ hostvars[groups['k3s_servers'][0]]['ansible_default_ipv4']['address'] | default(groups['k3s_servers'][0]) }}:{{ k3s_https_listen_port }}"
+      k3s_server_url: >-
+          https://{{ hostvars[groups['k3s_servers'][0]]['ansible_facts']['default_ipv4']['address']
+          | default(groups['k3s_servers'][0]) }}:{{ k3s_https_listen_port }}
   when:
       - k3s_server_url == ""
       - k3s_role == "agent"
@@ -167,7 +182,7 @@
 # K3s upgrade path validation - only one minor version step allowed
 - name: Validate k3s upgrade path
   vars:
-      current_minor: "{{ ansible_local.k3s.service.version | regex_replace('^v\\d+\\.(\\d+)\\..*', '\\1') | int }}"
+      current_minor: "{{ ansible_facts['ansible_local']['k3s'].service.version | regex_replace('^v\\d+\\.(\\d+)\\..*', '\\1') | int }}"
       target_minor: "{{ k3s_version | regex_replace('^v\\d+\\.(\\d+)\\..*', '\\1') | int }}"
   ansible.builtin.assert:
       that:
@@ -175,12 +190,12 @@
           - (target_minor | int) - (current_minor | int) <= 1
       fail_msg: >-
           K3s version change not allowed from
-          {{ ansible_local.k3s.service.version }} to {{ k3s_version }}.
+          {{ ansible_facts['ansible_local']['k3s'].service.version }} to {{ k3s_version }}.
           Downgrades are not supported. Upgrades must be one minor version at a time.
   when:
-      - ansible_local.k3s.service.binary_installed | bool
-      - ansible_local.k3s.service.version | default('unknown') != 'unknown'
-      - ansible_local.k3s.service.version != k3s_version
+      - ansible_facts['ansible_local']['k3s'].service.binary_installed | bool
+      - ansible_facts['ansible_local']['k3s'].service.version | default('unknown') != 'unknown'
+      - ansible_facts['ansible_local']['k3s'].service.version != k3s_version
 
 # K3s binary installation - checksum-verified download
 - name: Download k3s SHA256 checksum file
@@ -191,8 +206,8 @@
       force: true
   become: true
   when: >-
-      (not ansible_local.k3s.service.binary_installed | bool
-      or ansible_local.k3s.service.version != k3s_version)
+      (not ansible_facts['ansible_local']['k3s'].service.binary_installed | bool
+      or ansible_facts['ansible_local']['k3s'].service.version != k3s_version)
       and not k3s_binary_checksum
 
 - name: Extract k3s binary checksum from release file
@@ -203,8 +218,8 @@
   changed_when: false
   become: true
   when: >-
-      (not ansible_local.k3s.service.binary_installed | bool
-      or ansible_local.k3s.service.version != k3s_version)
+      (not ansible_facts['ansible_local']['k3s'].service.binary_installed | bool
+      or ansible_facts['ansible_local']['k3s'].service.version != k3s_version)
       and not k3s_binary_checksum
 
 - name: Download k3s binary
@@ -217,8 +232,8 @@
       checksum: "sha256:{{ k3s_binary_checksum if k3s_binary_checksum else k3s_release_checksum.stdout }}"
   become: true
   when: >-
-      not ansible_local.k3s.service.binary_installed | bool
-      or ansible_local.k3s.service.version != k3s_version
+      not ansible_facts['ansible_local']['k3s'].service.binary_installed | bool
+      or ansible_facts['ansible_local']['k3s'].service.version != k3s_version
   notify: Restart k3s
 
 - name: Create k3s configuration directory

--- a/roles/k3s/tasks/system_preparation.yml
+++ b/roles/k3s/tasks/system_preparation.yml
@@ -61,7 +61,7 @@
 - name: Disable swap if enabled (Kubernetes requirement)
   ansible.builtin.command: swapoff -a
   become: true
-  when: ansible_swaptotal_mb > 0
+  when: ansible_facts['swaptotal_mb'] > 0
   changed_when: true
 
 - name: Comment out swap entries in /etc/fstab
@@ -70,4 +70,4 @@
       regexp: '^([^#].*\sswap\s.*)$'
       replace: '# \1'
   become: true
-  when: ansible_swaptotal_mb > 0
+  when: ansible_facts['swaptotal_mb'] > 0

--- a/roles/k3s/templates/etc/rancher/k3s/agent-config.yaml.j2
+++ b/roles/k3s/templates/etc/rancher/k3s/agent-config.yaml.j2
@@ -8,15 +8,15 @@
 {#- Auto-discovery logic for server URL when not explicitly configured -#}
 {%- if k3s_server_url is defined and k3s_server_url -%}
 {%-   set _ = k3s_agent_config.update({'server': k3s_server_url}) -%}
-{%- elif ansible_local.k3s.cluster_info.server_url is defined and ansible_local.k3s.cluster_info.server_url -%}
-{%-   set _ = k3s_agent_config.update({'server': ansible_local.k3s.cluster_info.server_url}) -%}
+{%- elif ansible_facts['ansible_local']['k3s'].cluster_info.server_url is defined and ansible_facts['ansible_local']['k3s'].cluster_info.server_url -%}
+{%-   set _ = k3s_agent_config.update({'server': ansible_facts['ansible_local']['k3s'].cluster_info.server_url}) -%}
 {%- elif groups['k3s_controllers'] is defined and groups['k3s_controllers'] | length > 0 -%}
 {%-   set server_host = groups['k3s_controllers'][0] -%}
-{%-   set server_ip = hostvars[server_host]['ansible_default_ipv4']['address'] | default(server_host) -%}
+{%-   set server_ip = hostvars[server_host]['ansible_facts']['default_ipv4']['address'] | default(server_host) -%}
 {%-   set _ = k3s_agent_config.update({'server': 'https://' + server_ip + ':' + (k3s_https_listen_port | default(6443) | string)}) -%}
 {%- elif groups['k3s_servers'] is defined and groups['k3s_servers'] | length > 0 -%}
 {%-   set server_host = groups['k3s_servers'][0] -%}
-{%-   set server_ip = hostvars[server_host]['ansible_default_ipv4']['address'] | default(server_host) -%}
+{%-   set server_ip = hostvars[server_host]['ansible_facts']['default_ipv4']['address'] | default(server_host) -%}
 {%-   set _ = k3s_agent_config.update({'server': 'https://' + server_ip + ':' + (k3s_https_listen_port | default(6443) | string)}) -%}
 {%- else -%}
 {#- Fallback: If no inventory groups are available, this will be handled by facts collection -#}
@@ -26,7 +26,7 @@
 {#- Auto-discovery logic for token when not explicitly configured -#}
 {%- if k3s_token is defined and k3s_token -%}
 {%-   set _ = k3s_agent_config.update({'token': k3s_token}) -%}
-{%- elif ansible_local.k3s.cluster.token_exists | default(false) -%}
+{%- elif ansible_facts['ansible_local']['k3s'].cluster.token_exists | default(false) -%}
 {#- Token will be retrieved automatically by the main tasks during execution -#}
 {%- endif -%}
 

--- a/tests/integration/targets/k3s/tasks/main.yml
+++ b/tests/integration/targets/k3s/tasks/main.yml
@@ -109,8 +109,8 @@
 
 - name: Check k3s facts
   ansible.builtin.debug:
-      var: ansible_local.k3s
-  when: ansible_local.k3s is defined
+      var: ansible_facts['ansible_local']['k3s']
+  when: ansible_facts['ansible_local']['k3s'] is defined
 
 - name: Verify k3s configuration directory exists
   ansible.builtin.stat:


### PR DESCRIPTION
## Summary

- Migrates the top-level `ansible_*` fact references an earlier pass missed, so
  the roles keep working once `INJECT_FACTS_AS_VARS` defaults to `false` in
  ansible-core 2.24 and the names are no longer auto-injected.
- Covers the `hostvars[...]['ansible_*']` lookups in the docker RedHat repo
  tasks and the k3s server-URL fallbacks, `ansible_local.k3s` →
  `ansible_facts['ansible_local']['k3s']` on the k3s cluster-init path and in
  the agent config template, plus `ansible_swaptotal_mb`, `ansible_os_family`
  and the commented-out `ansible_selinux`/`ansible_apparmor` references.
- Custom facts are the exception to the renaming rule: inside `ansible_facts`
  they keep the full `ansible_local` key rather than dropping the `ansible_`
  prefix the way built-in facts do.
- The docker RedHat repo tasks now read `ansible_facts["..."]` directly instead
  of going through `hostvars[inventory_hostname]`, which is equivalent on the
  target host and keeps the lines readable.

## Test plan

- [ ] CI green — `molecule-k3s` is the meaningful gate here, since it is the
      scenario that exercises the custom-fact lookups on a real node
- [x] Custom-fact resolution verified against a local `facts.d` script:
      `ansible_facts['ansible_local']['k3s']` and the `hostvars[...]
      ['ansible_facts'][...]` lookups both resolve
- [x] `ansible-lint --profile=production` green in CI (it cannot run on the
      build host, PyPI is unreachable there)
- [x] `yamllint` clean, no new findings beyond the pre-existing long lines
- [x] All changed YAML parses, `agent-config.yaml.j2` parses as a Jinja template
- [x] Repo-wide grep confirms no top-level fact references remain; magic vars
      such as `ansible_check_mode`, `ansible_become` and `ansible_job_id` are
      unaffected by the deprecation and stay as they are