### PR TITLE
fix(k3s): keep cluster-init stable once the server runs the cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **k3s `cluster-init` drift on re-runs**: the first server still rewrote
+- **k3s `cluster-init` drift on re-runs**: the first server rewrote
   `config.yaml` and restarted k3s on every run after the first. `cluster-init`
-  was derived from `k3s_server_init`, which in turn follows `should_init` and
-  flips to false as soon as the datastore exists — so the flag was written on
-  the initial run and dropped on every later one. `cluster-init` is a bootstrap
-  flag that k3s only evaluates while creating the datastore, so it is now tied
-  to the node's role in the cluster rather than to whether the datastore
-  happens to exist. Secondary servers and agents keep writing `server:` as
+  was derived from `k3s_server_init`, which follows `should_init` and requires
+  the datastore to be absent — so the flag was written on the initial run and
+  dropped on every later one. `cluster-init` is a bootstrap flag that k3s only
+  evaluates while creating the datastore, so it is now kept for as long as this
+  node runs the cluster. Secondary servers and agents keep writing `server:` as
   before.
 - **k3s config drift on re-runs**: a server rewrote `config.yaml` and restarted
   k3s on every run after the first. On the initial run the cluster database does

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **k3s `cluster-init` drift on re-runs**: the first server still rewrote
+  `config.yaml` and restarted k3s on every run after the first. `cluster-init`
+  was derived from `k3s_server_init`, which in turn follows `should_init` and
+  flips to false as soon as the datastore exists — so the flag was written on
+  the initial run and dropped on every later one. `cluster-init` is a bootstrap
+  flag that k3s only evaluates while creating the datastore, so it is now tied
+  to the node's role in the cluster rather than to whether the datastore
+  happens to exist. Secondary servers and agents keep writing `server:` as
+  before.
 - **k3s config drift on re-runs**: a server rewrote `config.yaml` and restarted
   k3s on every run after the first. On the initial run the cluster database does
   not exist yet, so the role initialises the cluster and `k3s_token` stays empty

--- a/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
+++ b/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
@@ -25,14 +25,19 @@
 {#- === CLUSTER INITIALIZATION === -#}
 {#- `cluster-init` is a bootstrap flag: k3s only evaluates it while creating
     the datastore, and it stays valid for the node that owns it afterwards.
-    Deriving it from `k3s_server_init` made it disappear once the datastore
-    existed — the flag was written on the first run and dropped on every
-    later one, rewriting config.yaml and restarting k3s each time. Keep it
-    tied to the node's role in the cluster instead, which does not change
-    when the datastore appears. -#}
-{%- if k3s_server_init is defined and k3s_server_init
+    Deriving it from `k3s_server_init` alone made it disappear once the
+    datastore existed — `should_init` requires the datastore to be absent, so
+    the flag was written on the first run and dropped on every later one,
+    rewriting config.yaml and restarting k3s each time.
+
+    Keep it once this node runs the cluster. `k3s_server_init` covers the run
+    that bootstraps it, `cluster.server_responsive` covers every run after,
+    and a server that joins another cluster carries `k3s_server_url` instead.
+    `cluster.initialized` is not usable here: it tests for the kine
+    `state.db`, which an etcd-backed server never creates. -#}
+{%- if (k3s_server_init is defined and k3s_server_init)
        or (k3s_role == 'server'
-           and ansible_local.k3s.cluster.first_server | default(false) | bool
+           and ansible_local.k3s.cluster.server_responsive | default(false) | bool
            and not (k3s_server_url is defined and k3s_server_url)) -%}
 {%-   set _ = k3s_config.update({'cluster-init': true}) -%}
 {%- elif k3s_server_url is defined and k3s_server_url -%}

--- a/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
+++ b/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
@@ -23,7 +23,17 @@
 {%- endif -%}
 
 {#- === CLUSTER INITIALIZATION === -#}
-{%- if k3s_server_init is defined and k3s_server_init -%}
+{#- `cluster-init` is a bootstrap flag: k3s only evaluates it while creating
+    the datastore, and it stays valid for the node that owns it afterwards.
+    Deriving it from `k3s_server_init` made it disappear once the datastore
+    existed — the flag was written on the first run and dropped on every
+    later one, rewriting config.yaml and restarting k3s each time. Keep it
+    tied to the node's role in the cluster instead, which does not change
+    when the datastore appears. -#}
+{%- if k3s_server_init is defined and k3s_server_init
+       or (k3s_role == 'server'
+           and ansible_local.k3s.cluster.first_server | default(false) | bool
+           and not (k3s_server_url is defined and k3s_server_url)) -%}
 {%-   set _ = k3s_config.update({'cluster-init': true}) -%}
 {%- elif k3s_server_url is defined and k3s_server_url -%}
 {%-   set _ = k3s_config.update({'server': k3s_server_url}) -%}


### PR DESCRIPTION
## Summary

- The first k3s server rewrote `config.yaml` and restarted k3s on **every run
  after the first**. This affects real deployments, not just tests.
- `cluster-init` was derived from `k3s_server_init`, which follows
  `should_init` — and `should_init` requires the datastore to be *absent*. So
  the flag was written on the bootstrap run and dropped on every later one:

  ```
  run 1:  cluster-domain: cluster.local   cluster-init: true   data-dir: …
  run 2:  cluster-domain: cluster.local                        data-dir: …
  ```

  That single line is the whole diff; everything else is byte-identical.
- k3s only evaluates `cluster-init` while creating the datastore, so it is now
  kept for as long as the node runs the cluster: `k3s_server_init` covers the
  bootstrap run, `cluster.server_responsive` every run after. A server joining
  another cluster carries `k3s_server_url` and is unaffected.

`cluster.initialized` cannot serve as the criterion — it tests for the kine
`state.db`, which an etcd-backed server never creates, and reads `false` on a
healthy cluster (confirmed in CI: `Cluster Initialized: False` while
`Server Responsive: True`). `cluster.first_server` is equally unusable: without
a `k3s_servers` inventory group it falls back to a datastore check and flips
the same way.

## Test plan

- [x] Verified against #142 (which enables `idempotence`): with this fix the
      `molecule-k3s` job passes, `failed=0`, on both Ubuntu 22.04 and Debian 12
- [x] Behaviour table checked against the real fact values from the CI logs:

  | case | rendered |
  | --- | --- |
  | bootstrap run (`server_init=true`) | `cluster-init` |
  | re-run (`server_responsive=true`) | `cluster-init` |
  | secondary server join | `server: …` |
  | agent | `server: …` |

- [ ] CI green
