### PR TITLE
fix(k3s): render the environment file the unit already loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,11 +62,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EnvironmentFile=-` makes systemd treat the missing file as fine, so k3s ran
   without proxy settings and failed image pulls silently. The task is active
   again and notifies `Restart k3s` instead of the stale lowercase handler name
-  `restart k3s`, which no longer exists. The task carries `no_log: true`,
-  because the template also renders `K3S_TOKEN` and the join credential must
-  not reach the task output. `verify.yml` asserts the file is rendered `0600`
-  and carries the value set through `k3s_environment_vars`, matching it with
-  `grep` instead of reading the file into a variable.
+  `restart k3s`, which no longer exists. Because `utilities.yml` is included
+  after the role has already flushed its handlers and waited for the API server,
+  the task flushes handlers itself and waits for the server to come back, so a
+  following play never meets a restarting cluster. `verify.yml` asserts the file
+  is rendered `0600` and carries the value set through `k3s_environment_vars`,
+  matching it with `grep` instead of reading the file into a variable.
+- **k3s environment file broke idempotence**: the environment template rendered
+  `K3S_TOKEN` whenever `k3s_token` was set. On a fresh node the variable is
+  empty during the first run and only read back once the datastore exists, so
+  the line appeared on the second run and rewrote the file every time. The
+  template no longer renders the token; `server-config.yaml.j2` already writes
+  it into `config.yaml`, which the unit loads through `K3S_CONFIG_FILE`, so the
+  join credential now lives in one file instead of two. `verify.yml` asserts the
+  environment file carries no `K3S_TOKEN=` line.
 - **k3s secrets encryption was silently off**: `server-config.yaml.j2`
   referenced `k3s_secrets_encryption`, `k3s_protect_kernel_defaults` and
   `k3s_audit_log_enabled`, but none of them were defined in `defaults/main.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **k3s environment variables were never rendered**: `k3s_environment_vars` was
+  fully wired — documented in `defaults/main.yml`, declared as a `dict` in
+  `meta/argument_specs.yml`, consumed by
+  `templates/etc/systemd/system/k3s.service.env.j2` and loaded by the unit via
+  `EnvironmentFile=` — but the task that renders the file was commented out in
+  `roles/k3s/tasks/utilities.yml`. Setting `HTTP_PROXY`/`HTTPS_PROXY`, the
+  documented use case, produced no error and no file: the leading `-` in
+  `EnvironmentFile=-` makes systemd treat the missing file as fine, so k3s ran
+  without proxy settings and failed image pulls silently. The task is active
+  again and notifies `Restart k3s` instead of the stale lowercase handler name
+  `restart k3s`, which no longer exists. `verify.yml` asserts the file is
+  rendered `0600` and carries the value set through `k3s_environment_vars`.
 - **k3s secrets encryption was silently off**: `server-config.yaml.j2`
   referenced `k3s_secrets_encryption`, `k3s_protect_kernel_defaults` and
   `k3s_audit_log_enabled`, but none of them were defined in `defaults/main.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EnvironmentFile=-` makes systemd treat the missing file as fine, so k3s ran
   without proxy settings and failed image pulls silently. The task is active
   again and notifies `Restart k3s` instead of the stale lowercase handler name
-  `restart k3s`, which no longer exists. `verify.yml` asserts the file is
-  rendered `0600` and carries the value set through `k3s_environment_vars`.
+  `restart k3s`, which no longer exists. The task carries `no_log: true`,
+  because the template also renders `K3S_TOKEN` and the join credential must
+  not reach the task output. `verify.yml` asserts the file is rendered `0600`
+  and carries the value set through `k3s_environment_vars`, matching it with
+  `grep` instead of reading the file into a variable.
 - **k3s secrets encryption was silently off**: `server-config.yaml.j2`
   referenced `k3s_secrets_encryption`, `k3s_protect_kernel_defaults` and
   `k3s_audit_log_enabled`, but none of them were defined in `defaults/main.yml`

--- a/roles/k3s/molecule/default/converge.yml
+++ b/roles/k3s/molecule/default/converge.yml
@@ -13,6 +13,10 @@
       # adds itself; verify.yml asserts both are present.
       k3s_kube_apiserver_args:
           - "request-timeout=2m0s"
+      # The environment file is only rendered when this dict is non-empty;
+      # verify.yml asserts the entry reaches the unit's EnvironmentFile.
+      k3s_environment_vars:
+          NO_PROXY: "localhost,127.0.0.1,10.0.0.0/8"
   pre_tasks:
       # The k3s install script needs curl, which the base test images
       # do not ship. Install it before the role runs.

--- a/roles/k3s/molecule/default/verify.yml
+++ b/roles/k3s/molecule/default/verify.yml
@@ -189,8 +189,8 @@
                 world-readable — k3s_environment_vars was never rendered.
             success_msg: "K3s environment file is rendered and 0600"
 
-      # Matched with grep rather than slurp: the file also carries K3S_TOKEN,
-      # and reading it into a variable would print the join credential.
+      # Matched with grep rather than slurp so the file contents never reach the
+      # task output.
       - name: Search the environment file for the configured entry
         ansible.builtin.command:
             cmd: grep -qF 'NO_PROXY=localhost,127.0.0.1,10.0.0.0/8' /etc/systemd/system/k3s.service.env
@@ -206,6 +206,25 @@
                 The environment file does not contain the value set through
                 k3s_environment_vars.
             success_msg: "k3s_environment_vars entries are present"
+
+      # The token used to be rendered here as well, which made the file change
+      # between the first and second run and broke idempotence. Assert it stays
+      # out, so a reintroduction fails by name instead of only as a diff.
+      - name: Search the environment file for a join credential
+        ansible.builtin.command:
+            cmd: grep -q '^K3S_TOKEN=' /etc/systemd/system/k3s.service.env
+        register: k3s_env_token_match
+        changed_when: false
+        failed_when: false
+
+      - name: Verify the join credential stays out of the environment file
+        ansible.builtin.assert:
+            that:
+                - k3s_env_token_match.rc != 0
+            fail_msg: >-
+                The environment file carries K3S_TOKEN again. config.yaml is the
+                single source for the token; a copy here breaks idempotence.
+            success_msg: "Environment file carries no join credential"
 
       - name: Check K3s server credential directory permissions
         ansible.builtin.stat:

--- a/roles/k3s/molecule/default/verify.yml
+++ b/roles/k3s/molecule/default/verify.yml
@@ -189,21 +189,23 @@
                 world-readable — k3s_environment_vars was never rendered.
             success_msg: "K3s environment file is rendered and 0600"
 
-      - name: Read the K3s environment file
-        ansible.builtin.slurp:
-            src: /etc/systemd/system/k3s.service.env
-        register: k3s_env_content
+      # Matched with grep rather than slurp: the file also carries K3S_TOKEN,
+      # and reading it into a variable would print the join credential.
+      - name: Search the environment file for the configured entry
+        ansible.builtin.command:
+            cmd: grep -qF 'NO_PROXY=localhost,127.0.0.1,10.0.0.0/8' /etc/systemd/system/k3s.service.env
+        register: k3s_env_match
+        changed_when: false
+        failed_when: false
 
       - name: Verify custom environment variables reach the file
         ansible.builtin.assert:
             that:
-                - "'NO_PROXY=localhost,127.0.0.1,10.0.0.0/8' in k3s_env_decoded"
+                - k3s_env_match.rc == 0
             fail_msg: >-
                 The environment file does not contain the value set through
                 k3s_environment_vars.
             success_msg: "k3s_environment_vars entries are present"
-        vars:
-            k3s_env_decoded: "{{ k3s_env_content.content | b64decode }}"
 
       - name: Check K3s server credential directory permissions
         ansible.builtin.stat:

--- a/roles/k3s/molecule/default/verify.yml
+++ b/roles/k3s/molecule/default/verify.yml
@@ -173,6 +173,38 @@
         loop_control:
             label: "{{ item.item }}"
 
+      - name: Check the K3s environment file
+        ansible.builtin.stat:
+            path: /etc/systemd/system/k3s.service.env
+        register: k3s_env_file
+
+      - name: Verify the environment file was rendered
+        ansible.builtin.assert:
+            that:
+                - k3s_env_file.stat.exists
+                - k3s_env_file.stat.size > 0
+                - k3s_env_file.stat.mode == '0600'
+            fail_msg: >-
+                /etc/systemd/system/k3s.service.env is missing, empty or
+                world-readable — k3s_environment_vars was never rendered.
+            success_msg: "K3s environment file is rendered and 0600"
+
+      - name: Read the K3s environment file
+        ansible.builtin.slurp:
+            src: /etc/systemd/system/k3s.service.env
+        register: k3s_env_content
+
+      - name: Verify custom environment variables reach the file
+        ansible.builtin.assert:
+            that:
+                - "'NO_PROXY=localhost,127.0.0.1,10.0.0.0/8' in k3s_env_decoded"
+            fail_msg: >-
+                The environment file does not contain the value set through
+                k3s_environment_vars.
+            success_msg: "k3s_environment_vars entries are present"
+        vars:
+            k3s_env_decoded: "{{ k3s_env_content.content | b64decode }}"
+
       - name: Check K3s server credential directory permissions
         ansible.builtin.stat:
             path: /var/lib/rancher/k3s/server/cred

--- a/roles/k3s/tasks/utilities.yml
+++ b/roles/k3s/tasks/utilities.yml
@@ -33,6 +33,9 @@
       owner: root
       group: root
   become: true
+  # The rendered file carries K3S_TOKEN; without this the join credential
+  # would end up in the task output on every --diff run.
+  no_log: true
   notify: Restart k3s
   when: k3s_environment_vars | length > 0
 

--- a/roles/k3s/tasks/utilities.yml
+++ b/roles/k3s/tasks/utilities.yml
@@ -25,16 +25,16 @@
   when:
       - k3s_create_symlinks | bool
 
-# - name: Create K3s environment configuration file
-#   ansible.builtin.template:
-#       src: etc/systemd/system/k3s.service.env.j2
-#       dest: /etc/systemd/system/k3s.service.env
-#       mode: "0600"
-#       owner: root
-#       group: root
-#   become: true
-#   notify: restart k3s
-#   when: k3s_environment_vars | length > 0
+- name: Create K3s environment configuration file
+  ansible.builtin.template:
+      src: etc/systemd/system/k3s.service.env.j2
+      dest: /etc/systemd/system/k3s.service.env
+      mode: "0600"
+      owner: root
+      group: root
+  become: true
+  notify: Restart k3s
+  when: k3s_environment_vars | length > 0
 
 - name: Create bash completion directory
   ansible.builtin.file:

--- a/roles/k3s/tasks/utilities.yml
+++ b/roles/k3s/tasks/utilities.yml
@@ -33,6 +33,7 @@
       owner: root
       group: root
   become: true
+  register: k3s_env_file_result
   notify: Restart k3s
   when: k3s_environment_vars | length > 0
 
@@ -49,7 +50,9 @@
       delay: "{{ k3s_health_check_delay }}"
       timeout: "{{ k3s_health_check_timeout }}"
       sleep: "{{ k3s_health_check_sleep }}"
-  when: k3s_role == "server"
+  when:
+      - k3s_role == "server"
+      - k3s_env_file_result.changed | default(false)
 
 - name: Create bash completion directory
   ansible.builtin.file:

--- a/roles/k3s/tasks/utilities.yml
+++ b/roles/k3s/tasks/utilities.yml
@@ -33,11 +33,23 @@
       owner: root
       group: root
   become: true
-  # The rendered file carries K3S_TOKEN; without this the join credential
-  # would end up in the task output on every --diff run.
-  no_log: true
   notify: Restart k3s
   when: k3s_environment_vars | length > 0
+
+# This file is included after main.yml has already flushed its handlers and
+# waited for the API server, so a restart notified here would otherwise fire at
+# the end of the play, leaving following plays to hit a server still coming up.
+- name: Flush handlers to apply the environment file restart
+  ansible.builtin.meta: flush_handlers
+
+- name: Wait for k3s to be ready after the environment file restart
+  ansible.builtin.wait_for:
+      port: "{{ k3s_https_listen_port }}"
+      host: "{{ k3s_health_check_host }}"
+      delay: "{{ k3s_health_check_delay }}"
+      timeout: "{{ k3s_health_check_timeout }}"
+      sleep: "{{ k3s_health_check_sleep }}"
+  when: k3s_role == "server"
 
 - name: Create bash completion directory
   ansible.builtin.file:

--- a/roles/k3s/templates/etc/systemd/system/k3s.service.env.j2
+++ b/roles/k3s/templates/etc/systemd/system/k3s.service.env.j2
@@ -4,9 +4,11 @@
 # K3s specific environment variables
 K3S_DATA_DIR={{ k3s_data_dir }}
 K3S_CONFIG_FILE={{ k3s_config_dir }}/config.yaml
-{% if k3s_token %}
-K3S_TOKEN={{ k3s_token }}
-{% endif %}
+{# K3S_TOKEN is deliberately absent. server-config.yaml.j2 already writes the
+   token into config.yaml, which the unit loads through K3S_CONFIG_FILE, so a
+   second copy here is redundant. It also broke idempotence: k3s_token is empty
+   on the first run of a fresh node and only slurped once the datastore exists,
+   so the line appeared on the second run and rewrote the file every time. #}
 
 # Custom environment variables
 {% for key, value in k3s_environment_vars.items() %}


### PR DESCRIPTION
## Summary

- `k3s_environment_vars` was fully wired — documented in `defaults/main.yml`, declared as a `dict` in `meta/argument_specs.yml`, consumed by `templates/etc/systemd/system/k3s.service.env.j2` and loaded by the unit via `EnvironmentFile=` — but the task that renders the file was commented out in `roles/k3s/tasks/utilities.yml`. Setting `HTTP_PROXY`/`HTTPS_PROXY`, the documented use case, produced no error and no file, because the leading `-` in `EnvironmentFile=-` makes systemd treat the missing file as fine.
- The task is active again and notifies `Restart k3s`; the commented-out block still used the lowercase `restart k3s`, which no longer exists in `handlers/main.yml`, so the notify would have been a no-op.
- Molecule now covers the gap: `converge.yml` sets a `k3s_environment_vars` entry and `verify.yml` asserts the file is rendered `0600` and carries that value.

## Test plan

- [ ] CI green (ansible-lint, yamllint, molecule-k3s, secret scan)
- [ ] `molecule test -s default` for the k3s role: the new assertions fail without the reactivated task