### PR TITLE
fix(docker): drop dead side_effect step from molecule sequence

### DIFF
--- a/roles/docker/molecule/default/molecule.yml
+++ b/roles/docker/molecule/default/molecule.yml
@@ -83,7 +83,6 @@ scenario:
         - prepare
         - converge
         - idempotence
-        - side_effect
         - verify
         - cleanup
         - destroy


### PR DESCRIPTION
## Summary

- The `docker` role's default molecule scenario listed `side_effect` in `test_sequence`, but the scenario ships no `side_effect.yml` and the provisioner maps no `side_effect` playbook, so the step never ran anything.
- Removed the entry; `verify` now follows `idempotence` directly. No playbook was added, since the role has no side effect worth exercising.

## Test plan

- [ ] `yamllint .` passes
- [ ] `ansible-lint` passes (production profile)
- [ ] `pytest tests/unit/` passes
- [ ] CI green