### PR TITLE
refactor(meta): unify the declared ansible floor at 2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `profile: production` and `strict: true`, and drops
   `var-naming[no-role-prefix]` from `skip_list`, which turns the prefix
   convention into an enforced rule. `package-latest` stays skipped.
+- **Unified the declared Ansible floor at `2.18`**: the collection declared its
+  minimum Ansible version in nine places with three different values. Galaxy
+  already enforces `requires_ansible: ">=2.18.0"` from `meta/runtime.yml` at
+  install time, while `README.md` promised `>= 2.15` and the `helm`/`fleet`
+  roles claimed `2.9`. `README.md` now states `>= 2.18` and all seven role
+  `min_ansible_version` values are `"2.18"`. For README readers this is a
+  documented tightening, even though Galaxy has been enforcing it all along.
+  `2.9` was unsupportable regardless, since the `community.docker` dependency
+  declared in `galaxy.yml` requires `>=3.4.11`, which does not run on it.
 - **BREAKING — k3s hardening now applies by default**: `k3s_secrets_encryption`,
   `k3s_anonymous_auth`, `k3s_node_restriction` and
   `k3s_kubelet_read_only_port_disabled` take effect on existing clusters running

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ collections:
 
 ## Requirements
 
-- Ansible >= 2.15
+- Ansible >= 2.18
 - Python >= 3.9
 
 ## Documentation

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
     author: "arillso (@arillso)"
     description: "Installs and configures Docker on Debian, RedHat, and Ubuntu."
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Debian
           versions:

--- a/roles/docker_compose_v2/meta/main.yml
+++ b/roles/docker_compose_v2/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
     author: "arillso (@arillso)"
     description: "Installs and configures Docker Compose 2 on Debian, RedHat, and Ubuntu."
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Debian
           versions:

--- a/roles/docker_login/meta/main.yml
+++ b/roles/docker_login/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
     author: "arillso (@arillso)"
     description: "Logs into Docker registries on Debian, RedHat, and Ubuntu."
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Debian
           versions:

--- a/roles/fleet/meta/main.yml
+++ b/roles/fleet/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     description: Manages Rancher Fleet GitRepos and Bundles on Kubernetes
     company: Arillso
     license: MIT
-    min_ansible_version: "2.9"
+    min_ansible_version: "2.18"
     platforms:
         - name: Ubuntu
           versions:

--- a/roles/helm/meta/main.yml
+++ b/roles/helm/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     description: Manages Helm Charts deployment on Kubernetes using Cattle Operator
     company: Arillso
     license: MIT
-    min_ansible_version: "2.9"
+    min_ansible_version: "2.18"
     platforms:
         - name: Ubuntu
           versions:

--- a/roles/k3s/meta/main.yml
+++ b/roles/k3s/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
     author: Arillso Team
     description: Lightweight Kubernetes distribution with security hardening
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Ubuntu
           versions:

--- a/roles/tailscale/meta/main.yml
+++ b/roles/tailscale/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
     author: Arillso Team
     description: "Manages Tailscale Kubernetes resources including ProxyGroups, Ingress, and Egress services."
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Ubuntu
           versions:


### PR DESCRIPTION
## Summary

- The collection declared its minimum Ansible version in nine places with three different values: `meta/runtime.yml` had `requires_ansible: ">=2.18.0"`, `README.md` promised `>= 2.15`, and the seven role `min_ansible_version` values were split between `2.15` and `2.9`. A user following the README installed and hit the Galaxy floor instead.
- Settled on `2.18` because that is the floor Galaxy actually enforces at install time — the only one that is real. `README.md` now states `>= 2.18` and all seven roles declare `min_ansible_version: "2.18"`; `meta/runtime.yml` is unchanged.
- `2.9` was unsupportable regardless: the `community.docker ">=3.4.11"` dependency declared in `galaxy.yml` does not run on it.
- Values are written as quoted strings so YAML does not parse `2.18` as a float.

## Test plan

- [ ] `ansible-lint` passes (`0 failure(s), 0 warning(s)` on 156 files, profile `production`)
- [ ] `yamllint .` clean, `markdownlint` and `prettier` clean on the changed Markdown
- [ ] All seven role meta files parse `min_ansible_version` as a string, not a float
- [ ] No `2.15`/`2.9` version floors remain outside historical CHANGELOG entries
- [ ] CI green