### PR TITLE
refactor(roles): prefix role-internal registers and enforce production profile

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,7 @@
 ---
+profile: production
+strict: true
+
 exclude_paths:
     - .ansible/
     - .github/
@@ -8,7 +11,6 @@ exclude_paths:
 
 skip_list:
     - galaxy[version-incorrect]
-    - var-naming[no-role-prefix]
     - command-instead-of-module
     - no-handler
     - package-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,15 +191,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Role-internal registers now carry a role prefix**: the 12 unprefixed
-  registers in `roles/helm` and `roles/k3s` were renamed to `_<role>_<name>`,
-  so role-internal state no longer leaks into the play namespace. Names such
-  as `cluster_token`, `kubeconfig_check` and `facts_check` became
-  `_k3s_cluster_token`, `_helm_kubeconfig_check` and `_k3s_facts_check`. The
-  molecule verify playbooks for `docker` and `k3s` use the plain
-  `<role>_<name>` form, since play-level variables are not role-internal.
-  `k3s_token`, `k3s_token_file` and `k3s_token_source` are the role interface
-  and are unchanged.
+- **Role-internal registers now carry a role prefix**: every register in
+  `roles/helm` and `roles/k3s` was renamed to `_<role>_<name>`, so
+  role-internal state no longer leaks into the play namespace. This covers
+  both the 12 registers that carried no role prefix at all (`cluster_token`,
+  `kubeconfig_check`, `facts_check` → `_k3s_cluster_token`,
+  `_helm_kubeconfig_check`, `_k3s_facts_check`) and the 16 that already had
+  one but no leading underscore (`helm_repo_check`, `k3s_release_checksum`,
+  `k3s_selinux_restorecon` → `_helm_repo_check`, `_k3s_release_checksum`,
+  `_k3s_selinux_restorecon`). The second group was already lint-clean;
+  renaming it keeps a single style inside the two roles. The molecule verify
+  playbooks for `docker` and `k3s` use the plain `<role>_<name>` form, since
+  play-level variables are not role-internal. `k3s_token`, `k3s_token_file`
+  and `k3s_token_source` are the role interface and are unchanged.
 - **`ansible-lint` runs the production profile**: `.ansible-lint` gains
   `profile: production` and `strict: true`, and drops
   `var-naming[no-role-prefix]` from `skip_list`, which turns the prefix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Role-internal registers now carry a role prefix**: the 12 unprefixed
+  registers in `roles/helm` and `roles/k3s` were renamed to `_<role>_<name>`,
+  so role-internal state no longer leaks into the play namespace. Names such
+  as `cluster_token`, `kubeconfig_check` and `facts_check` became
+  `_k3s_cluster_token`, `_helm_kubeconfig_check` and `_k3s_facts_check`. The
+  molecule verify playbooks for `docker` and `k3s` use the plain
+  `<role>_<name>` form, since play-level variables are not role-internal.
+  `k3s_token`, `k3s_token_file` and `k3s_token_source` are the role interface
+  and are unchanged.
+- **`ansible-lint` runs the production profile**: `.ansible-lint` gains
+  `profile: production` and `strict: true`, and drops
+  `var-naming[no-role-prefix]` from `skip_list`, which turns the prefix
+  convention into an enforced rule. `package-latest` stays skipped.
 - **BREAKING — k3s hardening now applies by default**: `k3s_secrets_encryption`,
   `k3s_anonymous_auth`, `k3s_node_restriction` and
   `k3s_kubelet_read_only_port_disabled` take effect on existing clusters running

--- a/roles/docker/molecule/default/verify.yml
+++ b/roles/docker/molecule/default/verify.yml
@@ -45,29 +45,29 @@
       - name: Check if daemon.json exists
         ansible.builtin.stat:
             path: /etc/docker/daemon.json
-        register: daemon_config
+        register: docker_daemon_config
 
       - name: Verify daemon configuration exists
         ansible.builtin.assert:
             that:
-                - daemon_config.stat.exists
+                - docker_daemon_config.stat.exists
             fail_msg: "Docker daemon configuration not found"
             success_msg: "Docker daemon configuration exists"
 
       - name: Read daemon configuration
         ansible.builtin.slurp:
             path: /etc/docker/daemon.json
-        register: daemon_content
+        register: docker_daemon_content
 
       - name: Parse daemon configuration
         ansible.builtin.set_fact:
-            daemon_json: "{{ daemon_content.content | b64decode | from_json }}"
+            docker_daemon_json: "{{ docker_daemon_content.content | b64decode | from_json }}"
 
       - name: Verify daemon configuration values
         ansible.builtin.assert:
             that:
-                - daemon_json['log-driver'] == 'json-file'
-                - daemon_json['storage-driver'] == 'overlay2'
+                - docker_daemon_json['log-driver'] == 'json-file'
+                - docker_daemon_json['storage-driver'] == 'overlay2'
             fail_msg: "Docker daemon configuration is incorrect"
             success_msg: "Docker daemon configuration is correct"
 
@@ -76,8 +76,8 @@
       - name: Verify role defaults survive a user-provided docker_daemon
         ansible.builtin.assert:
             that:
-                - daemon_json['live-restore']
-                - daemon_json['no-new-privileges']
+                - docker_daemon_json['live-restore']
+                - docker_daemon_json['no-new-privileges']
             fail_msg: "Role defaults were replaced instead of merged"
             success_msg: "Role defaults merged with the user configuration"
 
@@ -86,8 +86,8 @@
       - name: Verify nested user log-opts survive the merge
         ansible.builtin.assert:
             that:
-                - daemon_json['log-opts']['max-size'] == '10m'
-                - daemon_json['log-opts']['max-file'] == '3'
+                - docker_daemon_json['log-opts']['max-size'] == '10m'
+                - docker_daemon_json['log-opts']['max-file'] == '3'
             fail_msg: "Nested log-opts were lost in the merge"
             success_msg: "Nested log-opts survived the merge"
 
@@ -100,8 +100,8 @@
       - name: Verify log-opts merges per sub-key when present on both sides
         ansible.builtin.assert:
             that:
-                - daemon_json['log-opts']['labels'] == 'from-base'
-                - daemon_json['log-opts']['max-size'] == '10m'
-                - daemon_json['log-opts']['max-file'] == '3'
+                - docker_daemon_json['log-opts']['labels'] == 'from-base'
+                - docker_daemon_json['log-opts']['max-size'] == '10m'
+                - docker_daemon_json['log-opts']['max-file'] == '3'
             fail_msg: "Nested merge replaced log-opts instead of merging sub-keys"
             success_msg: "Nested dicts merge per sub-key"

--- a/roles/helm/tasks/charts.yml
+++ b/roles/helm/tasks/charts.yml
@@ -8,14 +8,14 @@
       kind: CustomResourceDefinition
       name: helmcharts.helm.cattle.io
       kubeconfig: "{{ helm_kubeconfig_path }}"
-  register: helm_crd_check
+  register: _helm_crd_check
   run_once: true
 
 - name: "Fail if Helm Controller CRD is not available"
   ansible.builtin.fail:
       msg: "Helm Controller CRD 'helmcharts.helm.cattle.io' is not available. Ensure K3s Helm Controller is running."
   when:
-      - helm_crd_check.resources | length == 0
+      - _helm_crd_check.resources | length == 0
   run_once: true
 
 - name: "Create namespaces for Helm charts"
@@ -92,7 +92,7 @@
   when:
       - helm_charts | length > 0
   run_once: true
-  register: helm_charts_status
+  register: _helm_charts_status
 
 - name: "Summary of Helm chart deployments"
   ansible.builtin.debug:

--- a/roles/helm/tasks/charts.yml
+++ b/roles/helm/tasks/charts.yml
@@ -59,7 +59,7 @@
   when:
       - helm_charts | length > 0
   run_once: true
-  register: charts_deployment_result
+  register: _helm_charts_deployment_result
 
 - name: "Wait for Helm charts to be ready"
   kubernetes.core.k8s_info:
@@ -76,7 +76,7 @@
   loop: "{{ helm_charts }}"
   when:
       - helm_deployment_wait | bool
-      - charts_deployment_result is changed
+      - _helm_charts_deployment_result is changed
   run_once: true
   retries: "{{ helm_validation_retries }}"
   delay: "{{ helm_validation_delay }}"

--- a/roles/helm/tasks/prerequisites.yml
+++ b/roles/helm/tasks/prerequisites.yml
@@ -5,7 +5,7 @@
 - name: "Find first existing kubeconfig file"
   ansible.builtin.stat:
       path: "{{ item }}"
-  register: kubeconfig_check
+  register: _helm_kubeconfig_check
   loop:
       - "/etc/rancher/k3s/k3s.yaml"
       - "/var/lib/rancher/k3s/server/cred/admin.kubeconfig"
@@ -17,16 +17,16 @@
 - name: "Set detected kubeconfig path to first existing file"
   ansible.builtin.set_fact:
       helm_kubeconfig_path: "{{ item.item }}"
-  loop: "{{ kubeconfig_check.results | default([]) }}"
+  loop: "{{ _helm_kubeconfig_check.results | default([]) }}"
   when:
-      - kubeconfig_check is defined
+      - _helm_kubeconfig_check is defined
       - item.stat.exists | default(false)
   run_once: true
 
 - name: "Validate final kubeconfig file exists"
   ansible.builtin.stat:
       path: "{{ helm_kubeconfig_path }}"
-  register: kubeconfig_stat
+  register: _helm_kubeconfig_stat
   run_once: true
 
 - name: "Fail if kubeconfig file does not exist"
@@ -40,7 +40,7 @@
           - ~/.kube/config
           Please ensure K3s is installed and running, or set helm_kubeconfig_path manually.
   when:
-      - not kubeconfig_stat.stat.exists
+      - not _helm_kubeconfig_stat.stat.exists
   run_once: true
 
 - name: "Check if Kubernetes cluster is accessible"
@@ -48,14 +48,14 @@
       api_version: v1
       kind: Node
       kubeconfig: "{{ helm_kubeconfig_path }}"
-  register: cluster_check
+  register: _helm_cluster_check
   run_once: true
 
 - name: "Fail if Kubernetes cluster is not accessible"
   ansible.builtin.fail:
       msg: "Kubernetes cluster is not accessible. Please ensure kubeconfig is valid and cluster is running."
   when:
-      - cluster_check.resources | length == 0
+      - _helm_cluster_check.resources | length == 0
   run_once: true
 
 - name: "Check if Cattle Operator (Helm Controller) is running"

--- a/roles/helm/tasks/prerequisites.yml
+++ b/roles/helm/tasks/prerequisites.yml
@@ -65,14 +65,14 @@
       name: helm-controller
       namespace: kube-system
       kubeconfig: "{{ helm_kubeconfig_path }}"
-  register: helm_controller_check
+  register: _helm_controller_check
   run_once: true
   failed_when: false
 
 - name: "Display Helm Controller status"
   ansible.builtin.debug:
       msg: |
-          Helm Controller Status: {% if helm_controller_check.resources | length > 0 %}Running{% else %}Not Found (may be embedded in K3s){% endif %}
+          Helm Controller Status: {% if _helm_controller_check.resources | length > 0 %}Running{% else %}Not Found (may be embedded in K3s){% endif %}
   run_once: true
 
 - name: "Display Helm configuration summary"

--- a/roles/helm/tasks/repositories.yml
+++ b/roles/helm/tasks/repositories.yml
@@ -14,5 +14,5 @@
   when:
       - helm_repositories | length > 0
   run_once: true
-  register: helm_repo_check
+  register: _helm_repo_check
   failed_when: false # Don't fail on repository access issues

--- a/roles/k3s/molecule/default/verify.yml
+++ b/roles/k3s/molecule/default/verify.yml
@@ -38,7 +38,7 @@
 
       - name: Test kubectl functionality
         ansible.builtin.command: kubectl version --client
-        register: kubectl_version
+        register: k3s_kubectl_version
         changed_when: false
         environment:
             KUBECONFIG: /etc/rancher/k3s/k3s.yaml
@@ -46,7 +46,7 @@
       - name: Verify kubectl is available
         ansible.builtin.assert:
             that:
-                - kubectl_version.rc == 0
+                - k3s_kubectl_version.rc == 0
             fail_msg: "Kubectl is not available"
             success_msg: "Kubectl is available"
 
@@ -81,13 +81,13 @@
       - name: Check kubeconfig file
         ansible.builtin.stat:
             path: /etc/rancher/k3s/k3s.yaml
-        register: kubeconfig_file
+        register: k3s_kubeconfig_file
 
       - name: Verify kubeconfig exists and is readable
         ansible.builtin.assert:
             that:
-                - kubeconfig_file.stat.exists
-                - kubeconfig_file.stat.mode == '0644'
+                - k3s_kubeconfig_file.stat.exists
+                - k3s_kubeconfig_file.stat.mode == '0644'
             fail_msg: "Kubeconfig file not found or not readable"
             success_msg: "Kubeconfig file exists and is readable"
 

--- a/roles/k3s/tasks/facts.yml
+++ b/roles/k3s/tasks/facts.yml
@@ -32,7 +32,7 @@
       mode: "0755"
   when:
       - k3s_auto_facts | default(true) | bool
-  register: k3s_facts_script_deployed
+  register: _k3s_facts_script_deployed
 
 # Refresh facts after deploying facts script
 - name: Refresh local facts after facts deployment
@@ -41,4 +41,4 @@
           - "!all"
           - "!any"
           - "local"
-  when: k3s_facts_script_deployed is changed
+  when: _k3s_facts_script_deployed is changed

--- a/roles/k3s/tasks/facts.yml
+++ b/roles/k3s/tasks/facts.yml
@@ -5,7 +5,7 @@
 - name: Check if K3s facts are available
   ansible.builtin.debug:
       msg: "Checking K3s facts availability"
-  register: facts_check
+  register: _k3s_facts_check
   changed_when: false
 
 - name: Gather existing local facts
@@ -14,7 +14,7 @@
           - "!all"
           - "!any"
           - "local"
-  register: current_facts
+  register: _k3s_current_facts
 
 # Deploy K3s facts script to collect and provide cluster information
 - name: Create facts.d directory

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -214,7 +214,7 @@
   ansible.builtin.shell:
       cmd: "set -o pipefail && grep ' k3s{{ k3s_suffix | default('') }}$' /tmp/k3s-sha256sum-{{ k3s_version }}.txt | awk '{print $1}'"
       executable: /bin/bash
-  register: k3s_release_checksum
+  register: _k3s_release_checksum
   changed_when: false
   become: true
   when: >-
@@ -229,7 +229,7 @@
       mode: "0755"
       owner: root
       group: root
-      checksum: "sha256:{{ k3s_binary_checksum if k3s_binary_checksum else k3s_release_checksum.stdout }}"
+      checksum: "sha256:{{ k3s_binary_checksum if k3s_binary_checksum else _k3s_release_checksum.stdout }}"
   become: true
   when: >-
       not ansible_facts['ansible_local']['k3s'].service.binary_installed | bool
@@ -242,8 +242,8 @@
 - name: Apply SELinux context to k3s binary
   ansible.builtin.command: restorecon -v /usr/local/bin/k3s
   become: true
-  register: k3s_selinux_restorecon
-  changed_when: "'restorecon reset' in k3s_selinux_restorecon.stdout"
+  register: _k3s_selinux_restorecon
+  changed_when: "'restorecon reset' in _k3s_selinux_restorecon.stdout"
   when:
       - ansible_facts['os_family'] == "RedHat"
       - k3s_security_hardening | default(true) | bool
@@ -373,7 +373,7 @@
   ansible.builtin.stat:
       path: "{{ k3s_data_dir }}/server/cred/admin.kubeconfig"
   become: true
-  register: k3s_kubeconfig_check
+  register: _k3s_kubeconfig_check
   when: k3s_role == "server"
 
 - name: Set kubeconfig permissions
@@ -383,7 +383,7 @@
       owner: "{{ k3s_kubeconfig_owner }}"
       group: "{{ k3s_kubeconfig_group }}"
   become: true
-  when: k3s_kubeconfig_check.stat.exists | default(false)
+  when: _k3s_kubeconfig_check.stat.exists | default(false)
 
 - name: Create k3s uninstall script
   ansible.builtin.template:

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -116,7 +116,7 @@
 - name: Retrieve token from first server (if not cluster init)
   ansible.builtin.slurp:
       src: "{{ k3s_token_file }}"
-  register: cluster_token
+  register: _k3s_cluster_token
   failed_when: false
   no_log: true
   when:
@@ -126,7 +126,7 @@
 
 - name: Set token from first server
   ansible.builtin.set_fact:
-      k3s_token: "{{ cluster_token.content | b64decode | trim }}"
+      k3s_token: "{{ _k3s_cluster_token.content | b64decode | trim }}"
       # True only when the token came from this node's own node-token file.
       # Such a token is redundant in config.yaml — it is absent on the first
       # run and present on every later one, which would rewrite the file and
@@ -137,9 +137,9 @@
   no_log: true
   when:
       - k3s_token == ""
-      - cluster_token is defined
-      - cluster_token.content is defined
-      - cluster_token.content | length > 0
+      - _k3s_cluster_token is defined
+      - _k3s_cluster_token.content is defined
+      - _k3s_cluster_token.content | length > 0
 
 # Server URL determination using facts with fallback logic
 - name: Set server URL from facts

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -70,7 +70,7 @@
         ansible.builtin.shell:
             cmd: set -o pipefail && getsebool -a | grep -E "(container_use_cephfs|virt_use_nfs)"
             executable: /bin/bash
-        register: available_sebools
+        register: _k3s_available_sebools
         failed_when: false
         changed_when: false
         become: true
@@ -84,7 +84,7 @@
             - container_use_cephfs
             - virt_use_nfs
         become: true
-        when: item in available_sebools.stdout
+        when: item in _k3s_available_sebools.stdout
         failed_when: false
 
       - name: Create custom SELinux policy for K3s (if needed)
@@ -180,7 +180,7 @@
             dest: /etc/apparmor.d/cri-containerd.apparmor.d
             mode: "0644"
         become: true
-        register: cri_containerd_profile_updated
+        register: _k3s_cri_containerd_profile_updated
         when: k3s_cri_apparmor_profile_enabled | default(true) | bool
 
       - name: Reload cri-containerd AppArmor profile
@@ -190,7 +190,7 @@
         become: true
         when:
             - k3s_cri_apparmor_profile_enabled | default(true) | bool
-            - cri_containerd_profile_updated is changed
+            - _k3s_cri_containerd_profile_updated is changed
         changed_when: true
 
       # Disable path: remove any previously deployed cri-containerd profile.
@@ -200,7 +200,7 @@
       - name: Stat existing cri-containerd AppArmor profile
         ansible.builtin.stat:
             path: /etc/apparmor.d/cri-containerd.apparmor.d
-        register: cri_containerd_profile_file
+        register: _k3s_cri_containerd_profile_file
         when: not (k3s_cri_apparmor_profile_enabled | default(true) | bool)
 
       - name: Unload cri-containerd AppArmor profile from kernel
@@ -209,9 +209,9 @@
         become: true
         when:
             - not (k3s_cri_apparmor_profile_enabled | default(true) | bool)
-            - cri_containerd_profile_file.stat.exists | default(false)
-        register: cri_containerd_profile_unloaded
-        changed_when: cri_containerd_profile_unloaded.rc == 0
+            - _k3s_cri_containerd_profile_file.stat.exists | default(false)
+        register: _k3s_cri_containerd_profile_unloaded
+        changed_when: _k3s_cri_containerd_profile_unloaded.rc == 0
         failed_when: false
         notify: Restart k3s
 
@@ -222,7 +222,7 @@
         become: true
         when:
             - not (k3s_cri_apparmor_profile_enabled | default(true) | bool)
-            - cri_containerd_profile_file.stat.exists | default(false)
+            - _k3s_cri_containerd_profile_file.stat.exists | default(false)
         notify: Restart k3s
 
       - name: Create AppArmor profile for K3s
@@ -311,14 +311,14 @@
             mode: "0644"
         become: true
         when: k3s_apparmor_profile | default(false) | bool
-        register: apparmor_profile_created
+        register: _k3s_apparmor_profile_created
 
       - name: Load K3s AppArmor profile
         ansible.builtin.command: apparmor_parser -r /etc/apparmor.d/k3s
         become: true
         when:
             - k3s_apparmor_profile | default(true) | bool
-            - apparmor_profile_created is changed
+            - _k3s_apparmor_profile_created is changed
         changed_when: true
 
 # General Security Hardening

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -39,7 +39,7 @@
             method: GET
             status_code: 200
             timeout: 10
-        register: k3s_selinux_repo_check
+        register: _k3s_selinux_repo_check
         failed_when: false
         when: ansible_facts['os_family'] == "RedHat"
 
@@ -51,9 +51,9 @@
         become: true
         when:
             - ansible_facts['os_family'] == "RedHat"
-            - k3s_selinux_repo_check.status == 200
+            - _k3s_selinux_repo_check.status == 200
         failed_when: false
-        register: k3s_selinux_install
+        register: _k3s_selinux_install
 
       - name: Configure SELinux context for K3s binary
         community.general.sefcontext:
@@ -330,7 +330,7 @@
   ansible.builtin.stat:
       path: "{{ k3s_token_file }}"
   become: true
-  register: k3s_token_file_check
+  register: _k3s_token_file_check
   when:
       - k3s_token_file is defined
       - k3s_token_file | length > 0
@@ -342,12 +342,12 @@
       owner: root
       group: root
   become: true
-  when: k3s_token_file_check.stat.exists | default(false)
+  when: _k3s_token_file_check.stat.exists | default(false)
 
 - name: Check if K3s server credential directory exists
   ansible.builtin.stat:
       path: "{{ k3s_data_dir }}/server/cred"
-  register: k3s_cred_dir_check
+  register: _k3s_cred_dir_check
 
 - name: Configure secure file permissions for K3s server credentials directory
   ansible.builtin.file:
@@ -357,7 +357,7 @@
       group: root
       state: directory
   become: true
-  when: k3s_cred_dir_check.stat.exists
+  when: _k3s_cred_dir_check.stat.exists
 
 - name: Configure logrotate for K3s logs
   ansible.builtin.template:

--- a/roles/k3s/tasks/utilities.yml
+++ b/roles/k3s/tasks/utilities.yml
@@ -6,12 +6,12 @@
 - name: Verify K3s binary is installed
   ansible.builtin.stat:
       path: /usr/local/bin/k3s
-  register: k3s_binary_check
+  register: _k3s_binary_check
 
 - name: Fail if K3s binary is not found
   ansible.builtin.fail:
       msg: "K3s binary not found at /usr/local/bin/k3s. This task file should only run after K3s installation."
-  when: not k3s_binary_check.stat.exists
+  when: not _k3s_binary_check.stat.exists
 
 - name: Create K3s utility symlinks
   ansible.builtin.file:
@@ -33,7 +33,7 @@
       owner: root
       group: root
   become: true
-  register: k3s_env_file_result
+  register: _k3s_env_file_result
   notify: Restart k3s
   when: k3s_environment_vars | length > 0
 
@@ -52,7 +52,7 @@
       sleep: "{{ k3s_health_check_sleep }}"
   when:
       - k3s_role == "server"
-      - k3s_env_file_result.changed | default(false)
+      - _k3s_env_file_result.changed | default(false)
 
 - name: Create bash completion directory
   ansible.builtin.file:
@@ -70,7 +70,7 @@
   ansible.builtin.command:
       cmd: /usr/local/bin/k3s completion bash
   become: true
-  register: k3s_completion_test
+  register: _k3s_completion_test
   changed_when: false
   failed_when: false
   when:
@@ -79,7 +79,7 @@
 
 - name: Create K3s bash completion
   ansible.builtin.copy:
-      content: "{{ k3s_completion_test.stdout }}\n"
+      content: "{{ _k3s_completion_test.stdout }}\n"
       dest: /etc/bash_completion.d/k3s
       mode: "0644"
       owner: root
@@ -88,14 +88,14 @@
   when:
       - k3s_create_bash_completion | default(true) | bool
       - ansible_facts['os_family'] in ['Debian', 'RedHat']
-      - k3s_completion_test.rc is defined
-      - k3s_completion_test.rc == 0
+      - _k3s_completion_test.rc is defined
+      - _k3s_completion_test.rc == 0
 
 - name: Generate kubectl bash completion
   ansible.builtin.command:
       cmd: /usr/local/bin/kubectl completion bash
   become: true
-  register: k3s_kubectl_completion_test
+  register: _k3s_kubectl_completion_test
   changed_when: false
   failed_when: false
   when:
@@ -106,7 +106,7 @@
 
 - name: Create kubectl bash completion (if kubectl symlink exists)
   ansible.builtin.copy:
-      content: "{{ k3s_kubectl_completion_test.stdout }}\n"
+      content: "{{ _k3s_kubectl_completion_test.stdout }}\n"
       dest: /etc/bash_completion.d/kubectl
       mode: "0644"
       owner: root
@@ -117,5 +117,5 @@
       - k3s_create_symlinks | bool
       - "'kubectl' in k3s_symlink_commands"
       - ansible_facts['os_family'] in ['Debian', 'RedHat']
-      - k3s_kubectl_completion_test.rc is defined
-      - k3s_kubectl_completion_test.rc == 0
+      - _k3s_kubectl_completion_test.rc is defined
+      - _k3s_kubectl_completion_test.rc == 0


### PR DESCRIPTION
## Summary

- Renames every register in `roles/helm` and `roles/k3s` to `_<role>_<name>`, so role-internal state no longer leaks into the play namespace. Two groups are involved: 12 registers that carried no role prefix at all (`cluster_token`, `kubeconfig_check`, `facts_check`), and 16 that already carried a role name but no leading underscore (`helm_repo_check`, `k3s_release_checksum`, `k3s_selinux_restorecon`).
- Only the first group was a lint failure. `var-naming[no-role-prefix]` applies `ident.lstrip("_")` before checking the prefix ([`var_naming.py:186`](https://github.com/ansible/ansible-lint/blob/main/src/ansiblelint/rules/var_naming.py#L186)), so `k3s_foo` and `_k3s_foo` both pass. The 16 are renamed for a single style inside the two roles, not to satisfy the linter.
- Removes `var-naming[no-role-prefix]` from the `.ansible-lint` skip list and adds `profile: production` plus `strict: true`, which turns the convention into an enforced rule. Config and renames ship together because the `ansible-lint` job has no `continue-on-error` and the collection build depends on it — split commits would leave a red intermediate state.
- `k3s_token`, `k3s_token_file` and `k3s_token_source` are the role interface and stay unchanged; `no_log: true` remains on both tasks handling the cluster token. `package-latest` stays in the skip list.
- The molecule verify playbooks for `docker` and `k3s` use the plain `<role>_<name>` form. Those are play-level variables, not role-internal state, so the leading underscore does not apply.

## Notes for review

- The prefix style follows `arillso.system`, where 93 of 97 registers use `_<role>_<name>` and the rule is enforced. The four exceptions confirm it: `ansible_role_packages`, `ansible_role_pipx_pkg` and `ansible_role_system_install` are caught by the `ansible_` exemption in the same rule, and `zram_comp_algorithm_raw` carries the role prefix without the underscore.
- `arillso.agent` is **not** a reference here: it keeps `var-naming[no-role-prefix]` in its skip list and mixes both forms (`_tailscale_package_installed` next to `tailscale_service`).
- This branch was rebased onto `main` after `e597070`, which removed the "Apply SELinux context to K3s binary" task from `roles/k3s/tasks/security.yml` and moved relabelling into `main.yml`. The rename of that task's register went with it, which is why the first group is 12 and not the 13 originally reported.

## Test plan

- [x] `ansible-lint` with the new config (`profile: production`, `strict: true`): clean on the full branch
- [x] No register without a `_<role>_` prefix left in `roles/helm/tasks` or `roles/k3s/tasks`
- [x] Every renamed register is file-local — no template, handler, or molecule reference to any old name anywhere in the repo
- [x] Public variables untouched: `defaults/`, `vars/` and `meta/argument_specs.yml` carry no change; `k3s_binary_checksum` survives next to the renamed `_k3s_release_checksum`
- [x] `yamllint`, `markdownlint`, `prettier` and `gitleaks` clean on the diff and on branch history
- [x] CHANGELOG entry under `## [Unreleased]` → `### Changed`
- [ ] CI green, including `molecule-k3s` (15 assertions covering the renamed k3s registers)

Note: `molecule-helm` runs a syntax-only verify playbook without assertions, so the helm registers are covered by `ansible-lint` and the rename gegenprobe rather than by the scenario.
