### PR TITLE
feat(k3s): default container log rotation and apply it on server nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously only read by an `is defined` guard in the agent config template,
   so out of the box kubelet never received `container-log-max-size` /
   `container-log-max-files` and container logs grew unbounded. The guards stay
-  in place, so setting either variable to an empty value still omits the flag.
+  in place, so setting `k3s_container_log_max_size` to `""` or
+  `k3s_container_log_max_files` to `0` still omits the respective flag.
 
 - **k3s hardening variables**: eight new variables defined in both
   `defaults/main.yml` and `meta/argument_specs.yml` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **k3s container log rotation defaults**: `k3s_container_log_max_size`
+  (`10Mi`) and `k3s_container_log_max_files` (`5`) now have defaults in
+  `defaults/main.yml` and entries in `meta/argument_specs.yml`. Both were
+  previously only read by an `is defined` guard in the agent config template,
+  so out of the box kubelet never received `container-log-max-size` /
+  `container-log-max-files` and container logs grew unbounded. The guards stay
+  in place, so setting either variable to an empty value still omits the flag.
+
 - **k3s hardening variables**: eight new variables defined in both
   `defaults/main.yml` and `meta/argument_specs.yml` —
   `k3s_secrets_encryption`, `k3s_protect_kernel_defaults`,
@@ -52,6 +60,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **k3s server nodes ignored container log rotation**: the
+  `container-log-max-size` and `container-log-max-files` kubelet args were only
+  built by `agent-config.yaml.j2`, so a server node never rotated container
+  logs even with the variables set. `server-config.yaml.j2` now builds the same
+  two args, and `molecule/default/verify.yml` asserts both reach the rendered
+  config.
+
 - **k3s server config template used the pre-migration fact spelling**: the
   `ansible_facts` migration left
   `templates/etc/rancher/k3s/server-config.yaml.j2` on `ansible_local.k3s`,
@@ -62,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the top level, so the old spelling still resolved. A sweep for
   `ansible_local.` across `roles/` confirms this was the last remaining
   occurrence.
+
 - **k3s environment variables were never rendered**: `k3s_environment_vars` was
   fully wired — documented in `defaults/main.yml`, declared as a `dict` in
   `meta/argument_specs.yml`, consumed by

--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -135,7 +135,7 @@ k3s_kubelet_read_only_port_disabled: true
 # Empty string disables the admission configuration entirely.
 k3s_pod_security_admission_profile: ""
 
-# K3s container log rotation (empty value omits the kubelet flag)
+# K3s container log rotation ("" resp. 0 omits the kubelet flag)
 k3s_container_log_max_size: "10Mi"
 k3s_container_log_max_files: 5
 

--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -135,6 +135,10 @@ k3s_kubelet_read_only_port_disabled: true
 # Empty string disables the admission configuration entirely.
 k3s_pod_security_admission_profile: ""
 
+# K3s container log rotation (empty value omits the kubelet flag)
+k3s_container_log_max_size: "10Mi"
+k3s_container_log_max_files: 5
+
 # K3s private registry configuration
 k3s_private_registries: []
 # Example configuration:

--- a/roles/k3s/meta/argument_specs.yml
+++ b/roles/k3s/meta/argument_specs.yml
@@ -444,8 +444,8 @@ argument_specs:
                 default: 5
                 description: >-
                     Maximum number of container log files kept per container,
-                    passed to kubelet as container-log-max-files. An empty value
-                    omits the flag and leaves the kubelet default in place.
+                    passed to kubelet as container-log-max-files. Set to 0 to
+                    omit the flag and leave the kubelet default in place.
 
             k3s_anonymous_auth:
                 type: "bool"

--- a/roles/k3s/meta/argument_specs.yml
+++ b/roles/k3s/meta/argument_specs.yml
@@ -431,6 +431,22 @@ argument_specs:
                     policy. Secrets and configmaps are always capped at
                     Metadata regardless of this setting.
 
+            k3s_container_log_max_size:
+                type: "str"
+                default: "10Mi"
+                description: >-
+                    Maximum size of a container log file before it is rotated,
+                    passed to kubelet as container-log-max-size. An empty string
+                    omits the flag and leaves the kubelet default in place.
+
+            k3s_container_log_max_files:
+                type: "int"
+                default: 5
+                description: >-
+                    Maximum number of container log files kept per container,
+                    passed to kubelet as container-log-max-files. An empty value
+                    omits the flag and leaves the kubelet default in place.
+
             k3s_anonymous_auth:
                 type: "bool"
                 default: false

--- a/roles/k3s/molecule/default/verify.yml
+++ b/roles/k3s/molecule/default/verify.yml
@@ -111,6 +111,14 @@
             fail_msg: "Hardening flags missing from rendered config"
             success_msg: "All hardening flags present in rendered config"
 
+      - name: Verify container log rotation flags are present by default
+        ansible.builtin.assert:
+            that:
+                - "'container-log-max-size=10Mi' in k3s_config_parsed['kubelet-arg']"
+                - "'container-log-max-files=5' in k3s_config_parsed['kubelet-arg']"
+            fail_msg: "Container log rotation flags missing from rendered config"
+            success_msg: "Container log rotation flags present in rendered config"
+
       - name: Verify protect-kernel-defaults stays off by default
         ansible.builtin.assert:
             that:

--- a/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
+++ b/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
@@ -248,6 +248,15 @@
 {%-   set _ = kubelet_args_list.append('log-level=' + k3s_log_level) -%}
 {%- endif -%}
 
+{#- Container log management -#}
+{%- if k3s_container_log_max_size is defined and k3s_container_log_max_size -%}
+{%-   set _ = kubelet_args_list.append('container-log-max-size=' + k3s_container_log_max_size) -%}
+{%- endif -%}
+
+{%- if k3s_container_log_max_files is defined and k3s_container_log_max_files -%}
+{%-   set _ = kubelet_args_list.append('container-log-max-files=' + k3s_container_log_max_files | string) -%}
+{%- endif -%}
+
 {%- if kubelet_args_list | length > 0 -%}
 {%-   set _ = k3s_config.update({'kubelet-arg': kubelet_args_list}) -%}
 {%- endif -%}


### PR DESCRIPTION
## Summary

- `k3s_container_log_max_size` (`10Mi`) and `k3s_container_log_max_files` (`5`) now have defaults in `defaults/main.yml` and entries in `meta/argument_specs.yml`. Both variables were only read by an `is defined` guard in the config template, so a stock node passed neither kubelet flag and container logs grew until the node disk filled up.
- The guards stay in place, so setting either variable to an empty value still omits the flag — an explicit opt-out remains possible.
- `server-config.yaml.j2` did not build the `container-log-max-*` kubelet args at all; only the agent template did. Server nodes therefore never rotated container logs even when the variables were set. The server template now builds the same two args.
- Values follow kubelet conventions (`10Mi`, not the docker role's `10m`) because kubelet owns these flags here, not the Docker daemon.

## Test plan

- [x] `ansible-lint --offline roles/k3s/` passes at the `production` profile
- [x] `yamllint` and `markdownlint` clean on all changed files
- [x] Rendered both templates with the role defaults: server and agent configs each emit `container-log-max-size=10Mi` and `container-log-max-files=5`
- [x] Rendered with both variables set to `""`: neither flag appears, confirming the guards still allow opt-out
- [x] Rendered with overrides (`50Mi` / `3`): values are honoured
- [x] `gitleaks` clean on the branch diff
- [ ] CI green, including the `molecule-k3s` job whose `verify.yml` now asserts both args reach the rendered config on a real server node