### PR TITLE
fix(molecule): use the k3s variables the role actually reads

### DIFF
--- a/roles/k3s/meta/argument_specs.yml
+++ b/roles/k3s/meta/argument_specs.yml
@@ -332,6 +332,11 @@ argument_specs:
                 default: {}
                 description: "Environment variables for K3s service"
 
+            k3s_write_kubeconfig_mode:
+                type: "str"
+                required: false
+                description: "File mode k3s writes the kubeconfig with"
+
             k3s_kubeconfig_mode:
                 type: "str"
                 default: "0644"

--- a/roles/k3s/molecule/default/converge.yml
+++ b/roles/k3s/molecule/default/converge.yml
@@ -4,10 +4,8 @@
   become: true
   vars:
       k3s_role: server
-      k3s_cluster_init: true
-      k3s_disable:
-          - traefik
-          - servicelb
+      k3s_disable_traefik: true
+      k3s_disable_servicelb: true
       k3s_write_kubeconfig_mode: "0644"
       # Passthrough args must survive alongside the hardening args the role
       # adds itself; verify.yml asserts both are present.


### PR DESCRIPTION
## Summary

- The k3s converge fixture set `k3s_cluster_init` and a `k3s_disable` list. The role reads neither, so traefik and servicelb kept running in the 3072 MB test VM even though the fixture asked for them to be off. Replaced with `k3s_disable_traefik` / `k3s_disable_servicelb`, the flags the server config template actually consumes.
- `k3s_cluster_init` is dropped rather than renamed. The scenario runs a single server, so the role's own `should_init` detection covers cluster init; an explicit override would defeat the path stabilised in #151.
- Declared `k3s_write_kubeconfig_mode` in `argument_specs.yml`. It is the one variable from that vars block that does take effect, and it was the only undeclared one. Declared `required: false` without a default, matching the template's `is defined` gate so omitting it stays valid.

## Test plan

- [x] Rendered `server-config.yaml.j2` with the old fixture vars: `disable=<absent>`, confirming the reported bug.
- [x] Rendered it with the new vars: `disable=['traefik', 'servicelb']`, `write-kubeconfig-mode=0644`, `cluster-init=<absent>`.
- [x] `validate_argument_spec` against the spec accepts the fixture vars, and still validates when `k3s_write_kubeconfig_mode` is omitted.
- [x] `ansible-lint --profile=production` on both changed files: 0 failures, 0 warnings.
- [x] yamllint, prettier, gitleaks clean.
- [ ] CI `molecule-k3s` green.