### PR TITLE
refactor(k3s): use the migrated fact spelling in the server config template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **k3s server config template used the pre-migration fact spelling**: the
+  `ansible_facts` migration left
+  `templates/etc/rancher/k3s/server-config.yaml.j2` on `ansible_local.k3s`,
+  while the sister template `agent-config.yaml.j2` in the same role had already
+  moved to `ansible_facts['ansible_local']['k3s']`. Both templates read the same
+  fact in two different spellings. No behaviour change: `ansible_local` is
+  exempt from the `INJECT_FACTS_AS_VARS` deprecation and is always promoted to
+  the top level, so the old spelling still resolved. A sweep for
+  `ansible_local.` across `roles/` confirms this was the last remaining
+  occurrence.
 - **k3s environment variables were never rendered**: `k3s_environment_vars` was
   fully wired — documented in `defaults/main.yml`, declared as a `dict` in
   `meta/argument_specs.yml`, consumed by

--- a/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
+++ b/roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2
@@ -41,7 +41,7 @@
     `state.db`, which an etcd-backed server never creates. -#}
 {%- if (k3s_server_init is defined and k3s_server_init)
        or (k3s_role == 'server'
-           and ansible_local.k3s.cluster.server_responsive | default(false) | bool
+           and ansible_facts['ansible_local']['k3s'].cluster.server_responsive | default(false) | bool
            and not (k3s_server_url is defined and k3s_server_url)) -%}
 {%-   set _ = k3s_config.update({'cluster-init': true}) -%}
 {%- elif k3s_server_url is defined and k3s_server_url -%}


### PR DESCRIPTION
## Summary

- The `ansible_facts` migration left `roles/k3s/templates/etc/rancher/k3s/server-config.yaml.j2` on the pre-migration `ansible_local.k3s` spelling, while its sister template `agent-config.yaml.j2` in the same role already read `ansible_facts['ansible_local']['k3s']`. One role read the same fact in two spellings.
- No behaviour change: `ansible_local` is exempt from the `INJECT_FACTS_AS_VARS` deprecation and is always promoted to the top level, so the old spelling still resolved. This is a consistency fix, not a bug fix.
- A sweep for `ansible_local.` across `roles/` confirms this was the last remaining occurrence, so the migration does not need a third pass.

## Test plan

- [ ] `rg "ansible_local\." roles/` returns no matches
- [ ] `ansible-lint roles/k3s/` passes
- [ ] CI green
