### PR TITLE
ci: wire up the security config, deps and SBOM reusables

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -13,7 +13,9 @@ concurrency:
     cancel-in-progress: false
 
 permissions:
-    contents: read
+    # security-sbom.yml declares `contents: write`; a called workflow never
+    # gets more than its caller grants, so the SBOM upload needs it here.
+    contents: write
     security-events: write
     actions: read
     pull-requests: read
@@ -26,3 +28,15 @@ jobs:
 
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-09
+
+    security-config:
+        uses: arillso/.github/.github/workflows/security-config.yml@2026-08-09
+        with:
+            scan-ansible: true
+            ansible-path: roles
+
+    security-sbom:
+        uses: arillso/.github/.github/workflows/security-sbom.yml@2026-08-09
+        with:
+            artifact-type: filesystem
+            artifact-ref: "."

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -124,6 +124,9 @@ jobs:
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-09
 
+    security-deps:
+        uses: arillso/.github/.github/workflows/security-deps.yml@2026-08-09
+
     claude-review:
         uses: arillso/.github/.github/workflows/ai-claude-review.yml@2026-08-09
         secrets:


### PR DESCRIPTION
## Summary

- Wires up three published `arillso/.github` reusables that had no caller in this repo, even though the substrate for all three is present.
- `security-config.yml` → `nightly-security.yml` with `scan-ansible: true` and `ansible-path: roles`.
- `security-deps.yml` → `pull-request.yml`, where `dependency-review` applies. The repo is public, so the job condition holds. There is no `go.mod`, and the reusable detects that after checkout and skips the Go audit with a notice, so no job fails.
- `security-sbom.yml` → `nightly-security.yml` with `artifact-type: filesystem` and `artifact-ref: "."`. Deliberately not in `tag.yml`: the reusable warns that a tag-triggered SBOM run creates a release if none exists and would race the dedicated release job. `attach-to-release` stays at its `false` default.
- `nightly-security.yml` needed `contents: write`: `security-sbom.yml` declares that permission and a called workflow never receives more than its caller grants. That workflow only runs on `schedule` and `workflow_dispatch`, so the widened scope is not reachable from a pull request.
- All calls are pinned to `@2026-08-09`, matching every other reusable call in the repo.

## Test plan

- [ ] `actionlint` and `yamllint` pass on both workflows
- [ ] CI green on this PR, including the new `security-deps` job
- [ ] After merge: trigger `nightly-security.yml` via `workflow_dispatch` and confirm `security-config` and `security-sbom` both complete
