### PR TITLE
fix(docs): exempt CLAUDE.md and PR template from MD041

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable-file MD041 -->
+
 ## Description
 
 <!-- Provide a clear and concise description of your changes -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
+<!-- markdownlint-disable-file MD041 -->
+
 @AGENTS.md


### PR DESCRIPTION
## Summary

- Add `<!-- markdownlint-disable-file MD041 -->` to `CLAUDE.md` and `.github/pull_request_template.md`; both legitimately start without a top-level heading, so `MD041/first-line-heading` fired on every commit that staged them.
- The lefthook `pre-commit` hook could only be bypassed with `--no-verify`, which also switched off gitleaks, yamllint, ansible-lint and actionlint.
- `.markdownlint.json` stays untouched: the exemption belongs on the individual files, not in the global rule set.

## Test plan

- [x] `npx markdownlint-cli2 CLAUDE.md .github/pull_request_template.md` before the change: 2 issues, both `MD041/first-line-heading`
- [x] Same command after the change: 0 issues
- [x] Repo-wide check: no other Markdown file starts without an H1
- [x] `pre-commit` hook (gitleaks, prettier, markdownlint) green on the actual commit