### PR TITLE
docs: drop references to the removed docker_compose v1 role

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,6 @@ ansible.container/
 │   └── tag.yml             # Galaxy publishing (triggered by tag)
 ├── roles/
 │   ├── docker/
-│   ├── docker_compose/
 │   ├── docker_compose_v2/
 │   ├── docker_login/
 │   ├── fleet/
@@ -32,7 +31,7 @@ ansible.container/
 ├── CHANGELOG.md
 ├── CONTRIBUTING.md
 ├── galaxy.yml
-├── pytest.ini
+├── pyproject.toml
 └── requirements.txt
 ```
 
@@ -76,7 +75,6 @@ structural gain. The role stays as it is.
 #### Docker Ecosystem
 
 - **docker** - Docker Engine installation (28.5.2)
-- **docker_compose** - Docker Compose v1
 - **docker_compose_v2** - Docker Compose v2 (5.1.0)
 - **docker_login** - Docker registry authentication
 
@@ -136,7 +134,7 @@ Tests run via the reusable CI (`arillso/.github`) on pull requests and merges.
 All versions managed by Renovate:
 
 - Docker: `docker_version` with renovate comment
-- Docker Compose: `docker_compose_version` / `docker_compose_v2_version`
+- Docker Compose: `docker_compose_v2_version`
 - K3s: `k3s_version`
 
 Format:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This is an Ansible collection that provides comprehensive roles for container an
 ### Docker Ecosystem
 
 - **[docker](roles/docker/README.md)** - Docker Engine installation and configuration with comprehensive daemon settings
-- **[docker_compose](roles/docker_compose/README.md)** - Docker Compose v1 (legacy) installation and management
 - **[docker_compose_v2](roles/docker_compose_v2/README.md)** - Docker Compose v2 (modern) installation as Docker CLI plugin
 - **[docker_login](roles/docker_login/README.md)** - Docker registry authentication management for multiple registries
 


### PR DESCRIPTION
## Summary

- `AGENTS.md` is loaded into every agent session via `CLAUDE.md`, but it still documented the `docker_compose` role, which no longer exists in `roles/` — agents planned against a role that was removed.
- The structure tree listed `pytest.ini` in the repo root; pytest is configured in `pyproject.toml` (`[tool.pytest.ini_options]`), so test config was documented at the wrong place.
- Also drops the now-orphaned `docker_compose_version` variable from Version Management and the broken `roles/docker_compose/README.md` link in `README.md`, both leftovers of the same removed role.

## Test plan

- [ ] `markdownlint` clean on `AGENTS.md` and `README.md`
- [ ] Markdown link check passes — no link to the non-existent `roles/docker_compose/`
- [ ] Remaining structure entries verified against the worktree: workflows, `plugins/filter`, `tests/integration`, `tests/unit` and all listed root files exist
- [ ] CI green