### PR TITLE
refactor(helm)!: remove five unused role variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Five unused helm variables**: `helm_target_groups`, `helm_target_host`,
+  `helm_kubectl_context`, `helm_validation_timeout` and `helm_log_level` are
+  gone from `roles/helm/defaults/main.yml` and
+  `roles/helm/meta/argument_specs.yml`. No task file in the role ever read
+  them, so setting them changed nothing and produced no warning.
+  `helm_target_groups` and `helm_target_host` were especially misleading: they
+  suggested the role filters its own target hosts, which it does not — host
+  selection belongs in the play (`hosts:`). Validation behaviour is unaffected:
+  `helm_validation_retries` and `helm_validation_delay` are read by
+  `roles/helm/tasks/charts.yml`, `helm_validation_enabled` by
+  `roles/helm/tasks/prerequisites.yml`, and together they cover the validation
+  flow.
+
 ### Added
 
 - **k3s container log rotation defaults**: `k3s_container_log_max_size`

--- a/roles/helm/defaults/main.yml
+++ b/roles/helm/defaults/main.yml
@@ -26,20 +26,9 @@ helm_chart_defaults:
     create_namespace: false
     timeout: "5m"
 
-helm_kubectl_context: ""
 helm_validation_enabled: true
-helm_validation_timeout: 300
 helm_validation_retries: 10
 helm_validation_delay: 30
 helm_deployment_wait: true
 helm_deployment_timeout: 600
 helm_debug_enabled: false
-helm_log_level: "info"
-
-helm_target_groups:
-    - "kubernetes_masters"
-    - "k3s_servers"
-    - "k8s_masters"
-    - "control_plane"
-
-helm_target_host: "{{ inventory_hostname }}"

--- a/roles/helm/meta/argument_specs.yml
+++ b/roles/helm/meta/argument_specs.yml
@@ -61,23 +61,11 @@ argument_specs:
                         default: "5m"
                         description: "Default timeout for Helm operations"
 
-            helm_kubectl_context:
-                type: "str"
-                required: false
-                default: ""
-                description: "Kubernetes context to use for Helm operations"
-
             helm_validation_enabled:
                 type: "bool"
                 required: false
                 default: true
                 description: "Enable post-deployment validation"
-
-            helm_validation_timeout:
-                type: "int"
-                required: false
-                default: 300
-                description: "Timeout for validation checks in seconds"
 
             helm_validation_retries:
                 type: "int"
@@ -108,27 +96,3 @@ argument_specs:
                 required: false
                 default: false
                 description: "Enable debug output for Helm commands"
-
-            helm_log_level:
-                type: "str"
-                required: false
-                default: "info"
-                choices: ["debug", "info", "warn", "error"]
-                description: "Helm log level"
-
-            helm_target_groups:
-                type: "list"
-                required: false
-                default:
-                    - "kubernetes_masters"
-                    - "k3s_servers"
-                    - "k8s_masters"
-                    - "control_plane"
-                elements: "str"
-                description: "Inventory groups to target for Helm operations"
-
-            helm_target_host:
-                type: "str"
-                required: false
-                default: "{{ inventory_hostname }}"
-                description: "Target host for Helm operations"


### PR DESCRIPTION
## Summary

- Removes `helm_target_groups`, `helm_target_host`, `helm_kubectl_context`, `helm_validation_timeout` and `helm_log_level` from `roles/helm/defaults/main.yml` and `roles/helm/meta/argument_specs.yml`. No task file in the role read any of them, so setting them changed nothing and produced no warning.
- `helm_target_groups` and `helm_target_host` were the most misleading of the five: they suggested the role filters its own target hosts. It does not — host selection belongs in the play's `hosts:` keyword.
- Validation behaviour is unchanged. `helm_validation_retries` and `helm_validation_delay` are read by `roles/helm/tasks/charts.yml`, `helm_validation_enabled` by `roles/helm/tasks/prerequisites.yml`.
- Breaking for anyone who sets these variables, though only as cleanup: the settings never had an effect. Migration notes are in the commit footer and `CHANGELOG.md`.

## Test plan

- [ ] `ansible-lint roles/helm/` passes (production profile, 14 files)
- [ ] `yamllint roles/helm/` passes
- [ ] Repo-wide grep for the five names returns no hits outside this diff
- [ ] CI green, including the per-role `molecule-helm` job