### PR TITLE
refactor(helm): run against every host instead of once per play

### DIFF
--- a/roles/helm/molecule/default/verify.yml
+++ b/roles/helm/molecule/default/verify.yml
@@ -4,11 +4,10 @@
 # the workload that Job released. Anything short of the Pod would pass
 # even if the controller never acted on the CR.
 #
-# Scoped to a single host, mirroring the role: every task in charts.yml
-# carries run_once, so the CR is applied to exactly one of the two VMs.
-# Each VM is its own k3s cluster, so asserting on both would fail on
-# whichever host the role skipped. run_once picks the same host the role
-# did, which keeps the assertions valid on either platform.
+# Asserted on every host, mirroring the role: each VM runs its own k3s
+# cluster, so the role applies the CR to all of them and every cluster
+# must carry the full chain. Scoping this to a single host would let a
+# role that silently skipped a cluster still pass.
 - name: Verify
   hosts: all
   become: true
@@ -25,7 +24,6 @@
             namespace: kube-system
             kubeconfig: "{{ helm_verify_kubeconfig }}"
         register: helm_verify_chart
-        run_once: true
 
       - name: Assert the HelmChart carries the role's spec and labels
         ansible.builtin.assert:
@@ -39,7 +37,6 @@
                     == "ansible-helm-role"
             fail_msg: "HelmChart 'podinfo' is missing or does not match the converge spec"
             success_msg: "HelmChart 'podinfo' applied with the expected spec"
-        run_once: true
 
       - name: Fetch the Helm install Job
         kubernetes.core.k8s_info:
@@ -49,7 +46,6 @@
             namespace: kube-system
             kubeconfig: "{{ helm_verify_kubeconfig }}"
         register: helm_verify_job
-        run_once: true
 
       - name: Assert the install Job succeeded
         ansible.builtin.assert:
@@ -58,7 +54,6 @@
                 - helm_verify_job.resources[0].status.succeeded | default(0) | int >= 1
             fail_msg: "Helm install Job 'helm-install-podinfo' did not complete successfully"
             success_msg: "Helm install Job 'helm-install-podinfo' completed"
-        run_once: true
 
       - name: Fetch the released pods
         kubernetes.core.k8s_info:
@@ -77,7 +72,6 @@
             | list | length >= 1
         retries: 30
         delay: 10
-        run_once: true
 
       - name: Assert the chart released a running pod
         ansible.builtin.assert:
@@ -88,4 +82,3 @@
                     | list | length >= 1
             fail_msg: "No running podinfo pod in namespace 'podinfo'"
             success_msg: "Chart released a running pod in namespace 'podinfo'"
-        run_once: true

--- a/roles/helm/tasks/charts.yml
+++ b/roles/helm/tasks/charts.yml
@@ -9,14 +9,12 @@
       name: helmcharts.helm.cattle.io
       kubeconfig: "{{ helm_kubeconfig_path }}"
   register: _helm_crd_check
-  run_once: true
 
 - name: "Fail if Helm Controller CRD is not available"
   ansible.builtin.fail:
       msg: "Helm Controller CRD 'helmcharts.helm.cattle.io' is not available. Ensure K3s Helm Controller is running."
   when:
       - _helm_crd_check.resources | length == 0
-  run_once: true
 
 - name: "Create namespaces for Helm charts"
   kubernetes.core.k8s:
@@ -29,7 +27,6 @@
   when:
       - item.create_namespace | default(helm_chart_defaults.create_namespace) | bool
       - item.namespace is defined or helm_chart_defaults.namespace != 'default'
-  run_once: true
 
 # Deploy all Helm charts
 - name: "Deploy Helm charts"
@@ -58,7 +55,6 @@
   loop: "{{ helm_charts }}"
   when:
       - helm_charts | length > 0
-  run_once: true
   register: _helm_charts_deployment_result
   # The k3s Helm controller owns the HelmChart it reconciles and writes back
   # to the spec, so the resource never matches what the role applied and this
@@ -87,7 +83,6 @@
       # molecule-idempotence-notest, so it is skipped there and never
       # registers its result.
       - _helm_charts_deployment_result | default({}) is changed
-  run_once: true
   retries: "{{ helm_validation_retries }}"
   delay: "{{ helm_validation_delay }}"
 
@@ -101,7 +96,6 @@
   loop: "{{ helm_charts }}"
   when:
       - helm_charts | length > 0
-  run_once: true
   register: _helm_charts_status
 
 - name: "Summary of Helm chart deployments"
@@ -118,4 +112,3 @@
           {% endfor %}
   when:
       - helm_charts | length > 0
-  run_once: true

--- a/roles/helm/tasks/prerequisites.yml
+++ b/roles/helm/tasks/prerequisites.yml
@@ -12,22 +12,34 @@
       - "/root/.kube/config"
       - "{{ ansible_facts['env']['HOME'] | default('/root') }}/.kube/config"
   when: helm_kubeconfig_path is not defined or helm_kubeconfig_path == ""
-  run_once: true
 
+# A set_fact in a loop has no break: every matching candidate overwrote
+# the previous one, so the *last* existing path won although the task
+# promises the first. selectattr picks the first match in one pass.
+# The stat guard comes first on purpose: the stat task above is
+# conditional, so its items may carry no stat dict at all, and Jinja
+# resolves the dotted path before the `defined` test would catch it.
 - name: "Set detected kubeconfig path to first existing file"
   ansible.builtin.set_fact:
-      helm_kubeconfig_path: "{{ item.item }}"
-  loop: "{{ _helm_kubeconfig_check.results | default([]) }}"
+      helm_kubeconfig_path: >-
+          {{ _helm_kubeconfig_check.results
+             | selectattr('stat', 'defined')
+             | selectattr('stat.exists', 'defined')
+             | selectattr('stat.exists')
+             | map(attribute='item')
+             | first }}
   when:
       - _helm_kubeconfig_check is defined
-      - item.stat.exists | default(false)
-  run_once: true
+      - _helm_kubeconfig_check.results | default([])
+        | selectattr('stat', 'defined')
+        | selectattr('stat.exists', 'defined')
+        | selectattr('stat.exists')
+        | list | length > 0
 
 - name: "Validate final kubeconfig file exists"
   ansible.builtin.stat:
       path: "{{ helm_kubeconfig_path }}"
   register: _helm_kubeconfig_stat
-  run_once: true
 
 - name: "Fail if kubeconfig file does not exist"
   ansible.builtin.fail:
@@ -41,7 +53,6 @@
           Please ensure K3s is installed and running, or set helm_kubeconfig_path manually.
   when:
       - not _helm_kubeconfig_stat.stat.exists
-  run_once: true
 
 - name: "Check if Kubernetes cluster is accessible"
   kubernetes.core.k8s_info:
@@ -49,14 +60,12 @@
       kind: Node
       kubeconfig: "{{ helm_kubeconfig_path }}"
   register: _helm_cluster_check
-  run_once: true
 
 - name: "Fail if Kubernetes cluster is not accessible"
   ansible.builtin.fail:
       msg: "Kubernetes cluster is not accessible. Please ensure kubeconfig is valid and cluster is running."
   when:
       - _helm_cluster_check.resources | length == 0
-  run_once: true
 
 - name: "Check if Cattle Operator (Helm Controller) is running"
   kubernetes.core.k8s_info:
@@ -66,14 +75,12 @@
       namespace: kube-system
       kubeconfig: "{{ helm_kubeconfig_path }}"
   register: _helm_controller_check
-  run_once: true
   failed_when: false
 
 - name: "Display Helm Controller status"
   ansible.builtin.debug:
       msg: |
           Helm Controller Status: {% if _helm_controller_check.resources | length > 0 %}Running{% else %}Not Found (may be embedded in K3s){% endif %}
-  run_once: true
 
 - name: "Display Helm configuration summary"
   ansible.builtin.debug:
@@ -84,4 +91,3 @@
           - Validation enabled: {{ helm_validation_enabled }}
           - Deployment wait: {{ helm_deployment_wait }}
           - Kubeconfig: {{ helm_kubeconfig_path }}
-  run_once: true

--- a/roles/helm/tasks/repositories.yml
+++ b/roles/helm/tasks/repositories.yml
@@ -13,6 +13,5 @@
   loop: "{{ helm_repositories | dict2items }}"
   when:
       - helm_repositories | length > 0
-  run_once: true
   register: _helm_repo_check
   failed_when: false # Don't fail on repository access issues

--- a/tests/unit/test_helm_per_host.py
+++ b/tests/unit/test_helm_per_host.py
@@ -1,0 +1,114 @@
+# Copyright: (c) 2024-2026, Arillso
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+"""Guards the per-host semantics of the helm role.
+
+Every host the role runs against is its own k3s cluster: the role's own
+default is `helm_target_host: "{{ inventory_hostname }}"`, the molecule
+scenario installs k3s on every VM, and the sister roles fleet, k3s and
+tailscale all run per host. A `run_once` anywhere in the role would apply
+the HelmChart CRs to exactly one host and leave the other clusters empty.
+
+The molecule scenario catches this too, but only in CI and only with two
+booted VMs. These checks are static: they read the repo, not a live host,
+so they run without qemu or a cluster.
+
+Parsing is deliberately line-based instead of using PyYAML, because
+`ansible-test units` runs without a tests/unit/requirements.txt and PyYAML
+is therefore not a guaranteed import in that environment.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# No pytest markers here: `ansible-test units` runs pytest with
+# --strict-markers against its own config, which does not know the
+# markers declared in pyproject.toml, and collection would fail.
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+HELM_TASKS = ["charts.yml", "main.yml", "prerequisites.yml", "repositories.yml"]
+
+# Roles that manage a cluster and therefore share the per-host contract.
+CLUSTER_ROLES = ["fleet", "helm", "k3s", "tailscale"]
+
+# A directive, not a mention: `run_once:` as a task key, so the prose in a
+# comment that explains why it is gone does not trip the assertion.
+RUN_ONCE = re.compile(r"^\s+run_once:", re.MULTILINE)
+
+
+def read(*parts):
+    return (REPO_ROOT.joinpath(*parts)).read_text()
+
+
+def run_once_lines(path):
+    """1-based line numbers carrying a run_once directive."""
+    text = path.read_text()
+    return [i for i, line in enumerate(text.splitlines(), 1) if RUN_ONCE.match(line + "\n")]
+
+
+@pytest.mark.parametrize("task_file", HELM_TASKS)
+def test_helm_tasks_run_on_every_host(task_file):
+    """One host per cluster: a skipped host never gets its HelmChart CR."""
+    path = REPO_ROOT / "roles" / "helm" / "tasks" / task_file
+    hits = run_once_lines(path)
+    assert not hits, f"roles/helm/tasks/{task_file} carries run_once at lines {hits}"
+
+
+def test_helm_verify_asserts_on_every_host():
+    """Verify must cover both VMs, otherwise the scenario is not a gate.
+
+    With run_once the verify simply followed the role onto whichever host
+    ansible picked, so a role that skipped a cluster still passed.
+    """
+    path = REPO_ROOT / "roles" / "helm" / "molecule" / "default" / "verify.yml"
+    hits = run_once_lines(path)
+    assert not hits, f"verify.yml carries run_once at lines {hits}"
+    assert re.search(
+        r"^\s*hosts:\s*all\s*$", path.read_text(), re.MULTILINE
+    ), "verify.yml must assert against hosts: all"
+
+
+@pytest.mark.parametrize("role", CLUSTER_ROLES)
+def test_cluster_roles_agree_on_per_host_execution(role):
+    """helm must not be the odd one out among the cluster-facing roles."""
+    tasks_dir = REPO_ROOT / "roles" / role / "tasks"
+    offenders = sorted(
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in tasks_dir.rglob("*.yml")
+        if run_once_lines(path)
+    )
+    assert not offenders, f"{role} deviates from per-host execution: {offenders}"
+
+
+def test_kubeconfig_autodetection_takes_the_first_match():
+    """The task is named "first existing file" and must deliver that.
+
+    A `set_fact` in a loop has no break: every matching candidate
+    overwrites the previous one, so the *last* existing path wins. On a
+    k3s server both /etc/rancher/k3s/k3s.yaml and /root/.kube/config
+    exist, and the loop picks the wrong one. run_once used to mask this,
+    because only one host ever ran the detection.
+    """
+    text = read("roles", "helm", "tasks", "prerequisites.yml")
+    block = text.split('- name: "Set detected kubeconfig path', 1)[1].split("\n- name:", 1)[0]
+    assert (
+        "loop:" not in block
+    ), "kubeconfig detection still loops over all candidates; the last match wins"
+    assert "| first" in block, "detection must select the first existing candidate"
+
+
+def test_kubeconfig_selection_survives_a_skipped_stat():
+    """The stat task is conditional, so its items may carry no stat dict.
+
+    Jinja resolves a dotted path left to right before the `defined` test
+    runs, so `selectattr('stat.exists', 'defined')` alone raises
+    UndefinedError on a skipped stat. The `stat`-level guard must come
+    first.
+    """
+    text = read("roles", "helm", "tasks", "prerequisites.yml")
+    assert (
+        "selectattr('stat', 'defined')" in text
+    ), "guard the stat dict itself before testing stat.exists"


### PR DESCRIPTION
## Summary

- Remove the 17 `run_once` directives from `roles/helm/tasks/`. Every host the role targets is its own k3s cluster, so `run_once` applied the HelmChart CRs to a single host and left the other clusters without any CR. The role's own default `helm_target_host: "{{ inventory_hostname }}"` and the sister roles `fleet`, `k3s` and `tailscale` all assume per-host execution.
- Fix the kubeconfig autodetection in `prerequisites.yml`, which was named "first existing file" but delivered the last one: a `set_fact` inside a loop has no break, so every later candidate overwrote the earlier match. On a k3s server both `/etc/rancher/k3s/k3s.yaml` and `/root/.kube/config` exist and the wrong one won. `run_once` masked this because only one host ever ran the detection, so removing it makes the fix a prerequisite rather than an optional extra.
- Roll back the `run_once` workaround in `molecule/default/verify.yml` so the scenario asserts on `hosts: all`. Until now the verify followed the role onto whichever host Ansible picked, which meant a role that silently skipped a cluster still passed.
- Add `tests/unit/test_helm_per_host.py` as a static regression guard, so the contract holds without booting two VMs.

Behaviour change worth noting for review: anyone running a play against several hosts of the *same* cluster now gets N applies instead of one. The HelmChart CR is declarative and `kubernetes.core.k8s` with `state: present` is idempotent, so this costs runtime, not correctness.

## Test plan

- [x] `python3 -m pytest tests/unit/` — 54 passed
- [x] New guard verified against the pre-change state: 7 failures covering every claim, so the test can actually fail
- [x] `ansible-lint` — 0 failures on 170 files, profile `production`
- [x] `yamllint`, `prettier`, `gitleaks` green via pre-commit hooks
- [ ] `molecule-helm` in CI: two VMs, each its own k3s cluster, both asserted