### PR TITLE
fix(lefthook): lint offline so commits survive without Galaxy access

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -29,7 +29,12 @@ pre-commit:
         ansible-lint:
             glob: "{roles,plugins,tests,meta}/**/*.{yml,yaml}"
             exclude: "(^\\.ansible/)"
-            run: ansible-lint --profile=production {staged_files}
+            # --offline keeps the hook from resolving the collections declared
+            # in roles/*/molecule/*/requirements.yml against galaxy.ansible.com.
+            # Without it a machine lacking Galaxy egress fails the hook and
+            # blocks the commit, which pushes people to --no-verify and drops
+            # the gitleaks hook below with it. CI lints online and is unchanged.
+            run: ansible-lint --offline --profile=production {staged_files}
         actionlint:
             glob: ".github/workflows/*.{yml,yaml}"
             run: actionlint {staged_files}


### PR DESCRIPTION
## Summary

- The `ansible-lint` pre-commit hook ran without `--offline`, so it resolved the collections declared in `roles/*/molecule/*/requirements.yml` (`arillso.system`) against galaxy.ansible.com. On a machine without Galaxy egress the hook exits non-zero and blocks every commit touching `{roles,plugins,tests,meta}/**/*.{yml,yaml}`, even when the lint content itself is clean.
- The obvious workaround, `git commit --no-verify`, disables the whole pre-commit chain including the `gitleaks` hook, so a linter's network failure silently removes the local secret-scanning layer.
- Fixed in the hook only, not in `.ansible-lint`. A config key would apply to every invocation including the CI lint job, which has network access and should keep resolving collections online.

## Test plan

- [x] Reproduced the failure with Galaxy pointed at an unreachable host: `ansible-galaxy collection install -vvv arillso.system:>=1.0.0, returned 1 code`
- [x] Same command with `--offline` under the same condition: `Passed: 0 failure(s), 0 warning(s) on 4 files`
- [x] `lefthook run pre-commit` with a staged file matching the hook glob: `ansible-lint` green
- [ ] CI green
