### PR TITLE
fix(helm): declare helm_kubeconfig_path in defaults and argument specs

### DIFF
--- a/roles/helm/defaults/main.yml
+++ b/roles/helm/defaults/main.yml
@@ -26,6 +26,10 @@ helm_chart_defaults:
     create_namespace: false
     timeout: "5m"
 
+# Empty so prerequisites.yml autodetects the path; a non-empty value here
+# would skip that detection.
+helm_kubeconfig_path: ""
+
 helm_validation_enabled: true
 helm_validation_retries: 10
 helm_validation_delay: 30

--- a/roles/helm/meta/argument_specs.yml
+++ b/roles/helm/meta/argument_specs.yml
@@ -61,6 +61,17 @@ argument_specs:
                         default: "5m"
                         description: "Default timeout for Helm operations"
 
+            helm_kubeconfig_path:
+                type: "str"
+                required: false
+                default: ""
+                description: |
+                    Path to the kubeconfig file used for all Kubernetes calls.
+                    Leave empty to autodetect the first existing file among
+                    /etc/rancher/k3s/k3s.yaml,
+                    /var/lib/rancher/k3s/server/cred/admin.kubeconfig,
+                    /root/.kube/config and ~/.kube/config.
+
             helm_validation_enabled:
                 type: "bool"
                 required: false


### PR DESCRIPTION
## Summary

- `roles/helm` read `helm_kubeconfig_path` in 13 task lines, including as `kubeconfig:` for every `kubernetes.core` call, but declared it in neither `defaults/main.yml` nor `meta/argument_specs.yml`. The variable was therefore undocumented for anyone wanting to set the path themselves, and argument-spec validation could not check its type.
- Declared it in both places, following the existing `helm_kubectl_context` precedent (`type: str`, `required: false`, empty default).
- The default is deliberately empty: `prerequisites.yml:14` only runs the autodetection while the value `is not defined or == ""`. A non-empty default would silently disable that detection.

## Test plan

- [x] `ansible-lint --profile=production roles/helm/`: `Passed: 0 failure(s), 0 warning(s) on 14 files`
- [x] Guard logic asserted both ways: empty default still triggers autodetection, an explicit path suppresses it
- [x] `lefthook run pre-commit`: `ansible-lint`, `yamllint`, `prettier`, `gitleaks` green
- [ ] CI green, including `ci / Argument Specs Check` and `molecule-helm`
