### PR TITLE
fix(docker_compose_v2): resolve the package pin per package manager

### DIFF
--- a/plugins/filter/DOCUMENTATION.yml
+++ b/plugins/filter/DOCUMENTATION.yml
@@ -99,7 +99,7 @@ filters:
             - apt matches an "=" pin against the full version string, which carries an optional epoch and a distro release suffix, and does not expand globs in that pin
             - A bare pin such as docker-ce=29.7.2 therefore never resolves, and neither does docker-ce=*29.7.2-*; only the string madison prints does
             - Returns none when the version is not in the repository, so the calling task can fail with a readable message instead of a Python traceback
-        version_added: "1.0.0"
+        version_added: "1.5.0"
         options:
             _input:
                 description:

--- a/plugins/filter/DOCUMENTATION.yml
+++ b/plugins/filter/DOCUMENTATION.yml
@@ -96,7 +96,9 @@ filters:
     apt_version_pin:
         description:
             - Pick the full apt version string for a marketing version out of apt-cache madison output
-            - apt matches an "=" pin against the full version string, which carries an optional epoch and a distro release suffix, and does not expand globs in that pin
+            - apt matches an "=" pin against the full version string, which carries
+              an optional epoch and a distro release suffix, and does not expand
+              globs in that pin
             - A bare pin such as docker-ce=29.7.2 therefore never resolves, and neither does docker-ce=*29.7.2-*; only the string madison prints does
             - Returns none when the version is not in the repository, so the calling task can fail with a readable message instead of a Python traceback
         version_added: "1.5.0"
@@ -111,7 +113,10 @@ filters:
             version:
                 description:
                     - The marketing version to resolve, for example 29.7.2 or 5.4.0
-                    - Matched on "(^|:)<version>-" so the version either opens the string or follows the epoch colon, and the trailing hyphen keeps 29.7.1 from taking 29.7.10 and rejects a bare prefix like 29.7
+                    - Matched on "(^|:)<version>-" so the version either opens the
+                      string or follows the epoch colon, and the trailing hyphen
+                      keeps 29.7.1 from taking 29.7.10 and rejects a bare prefix
+                      like 29.7
                     - Dots are matched literally, so 5.4.0 does not also match a 5X4X0 build
                 type: string
                 required: true

--- a/plugins/filter/DOCUMENTATION.yml
+++ b/plugins/filter/DOCUMENTATION.yml
@@ -93,10 +93,55 @@ filters:
                 description: String converted to camelCase format
                 type: string
 
+    apt_version_pin:
+        description:
+            - Pick the full apt version string for a marketing version out of apt-cache madison output
+            - apt matches an "=" pin against the full version string, which carries an optional epoch and a distro release suffix, and does not expand globs in that pin
+            - A bare pin such as docker-ce=29.7.2 therefore never resolves, and neither does docker-ce=*29.7.2-*; only the string madison prints does
+            - Returns none when the version is not in the repository, so the calling task can fail with a readable message instead of a Python traceback
+        version_added: "1.0.0"
+        options:
+            _input:
+                description:
+                    - Lines of apt-cache madison <package> output, typically stdout_lines of the command
+                    - Each line looks like "<package> | <version> | <repository>"; only the middle field is read
+                type: list
+                elements: string
+                required: true
+            version:
+                description:
+                    - The marketing version to resolve, for example 29.7.2 or 5.4.0
+                    - Matched on "(^|:)<version>-" so the version either opens the string or follows the epoch colon, and the trailing hyphen keeps 29.7.1 from taking 29.7.10 and rejects a bare prefix like 29.7
+                    - Dots are matched literally, so 5.4.0 does not also match a 5X4X0 build
+                type: string
+                required: true
+        examples:
+            - name: Resolve an apt pin at runtime
+              description: Look up the exact version string before pinning it
+              code: |
+                  - name: Resolve the apt version string for the pin
+                    ansible.builtin.command:
+                      cmd: apt-cache madison docker-compose-plugin
+                    register: compose_madison
+                    changed_when: false
+
+                  - name: Set the resolved apt version string
+                    ansible.builtin.set_fact:
+                      docker_compose_v2_apt_version: >-
+                        {{ compose_madison.stdout_lines
+                           | arillso.container.apt_version_pin(docker_compose_v2_version) }}
+                    # Returns: 5.4.0-1~ubuntu.24.04~noble
+
+        return:
+            _value:
+                description: Full apt version string including epoch and distro suffix, or none when no line matches
+                type: string
+
 notes:
-    - These filters are specifically designed for Rancher Fleet GitOps target configurations
+    - The Fleet filters are specifically designed for Rancher Fleet GitOps target configurations
     - Common transformations include cluster_selector -> clusterSelector, match_labels -> matchLabels
-    - The filters preserve all values unchanged, only transforming dictionary keys
+    - The Fleet filters preserve all values unchanged, only transforming dictionary keys
+    - apt_version_pin never raises on a missing version; the readable error belongs in an ansible.builtin.fail task
     - Nested structures are handled recursively
 
 seealso:

--- a/plugins/filter/README.md
+++ b/plugins/filter/README.md
@@ -108,6 +108,60 @@ Converts a single snake_case string to camelCase format.
 | `my_variable_name` | `myVariableName`  |
 | `api_version`      | `apiVersion`      |
 
+### apt_version_pin
+
+Resolves the full apt version string for a marketing version out of
+`apt-cache madison` output.
+
+**Purpose:** apt matches an `=` pin against the _full_ version string, which
+carries an optional epoch and a distro release suffix (e.g.
+`5:29.7.2-1~ubuntu.24.04~noble`), and it does not expand globs in that pin. A
+bare `docker-ce=29.7.2` therefore never resolves, and neither does
+`docker-ce=*29.7.2-*` — only the string madison prints does. The filter picks
+that string, so roles can pin an exact version without hand-rolling a regex in
+Jinja.
+
+The match anchors on `(^|:)<version>-`: the version either opens the string or
+follows the epoch colon, and the trailing hyphen keeps `29.7.1` from taking
+`29.7.10` and rejects a bare prefix like `29.7`. Dots are matched literally, so
+`5.4.0` does not also match a `5X4X0` build.
+
+**Usage:**
+
+```yaml
+- name: Resolve the apt version string for the pin
+  ansible.builtin.command:
+      cmd: apt-cache madison docker-compose-plugin
+  register: compose_madison
+  changed_when: false
+
+- name: Set the resolved apt version string
+  ansible.builtin.set_fact:
+      docker_compose_v2_apt_version: >-
+          {{ compose_madison.stdout_lines
+             | arillso.container.apt_version_pin(docker_compose_v2_version) }}
+```
+
+The filter returns `none` when the repository no longer carries the version —
+Docker drops old packages — instead of raising, so the calling role can fail
+with a readable message rather than a Python traceback:
+
+```yaml
+- name: Fail when the pinned version is not in the repository
+  ansible.builtin.fail:
+      msg: "docker_compose_v2_version {{ docker_compose_v2_version }} is not available"
+  when: docker_compose_v2_apt_version | length == 0
+```
+
+**Examples:**
+
+| madison version            | Requested | Result                        |
+| -------------------------- | --------- | ----------------------------- |
+| `5.4.0-1~ubuntu.24.04~no…` | `5.4.0`   | `5.4.0-1~ubuntu.24.04~noble`  |
+| `5:29.7.2-1~ubuntu.24.04…` | `29.7.2`  | `5:29.7.2-1~ubuntu.24.04~no…` |
+| `5:29.7.10-1~ubuntu.24.0…` | `29.7.1`  | no match on this line         |
+| any                        | `29.7`    | `none` (bare prefix)          |
+
 ## Integration with Fleet Role
 
 These filters are automatically used by the `arillso.container.fleet` role when
@@ -153,20 +207,18 @@ You can test these filters using ansible-playbook:
 The filters are implemented in Python and follow Ansible's filter plugin
 conventions:
 
-- **Location:** `plugins/filter/fleet_filters.py`
-- **Documentation:**
-    - Python module: DOCUMENTATION, EXAMPLES, and RETURN sections
-    - YAML format: `DOCUMENTATION.yml` for collection integration
+- **Location:** `plugins/filter/fleet_filters.py` (`fleet_transform_targets`, `to_camel_case`) and `plugins/filter/apt_filters.py` (`apt_version_pin`)
+- **Documentation:** DOCUMENTATION, EXAMPLES, and RETURN sections in the Python module, plus `DOCUMENTATION.yml` for collection integration
 - **Python Version:** Compatible with Python 3.6+
 - **Dependencies:** No external dependencies required
-- **Unit Tests:** `tests/unit/plugins/filter/test_fleet_filters.py`
+- **Unit Tests:** `tests/unit/plugins/filter/test_fleet_filters.py` and `tests/unit/plugins/filter/test_apt_filters.py`
 
 ## Documentation
 
 Detailed filter documentation is available in multiple formats:
 
 - **YAML Documentation:** [DOCUMENTATION.yml](DOCUMENTATION.yml) - Structured documentation for the collection
-- **Python Docstrings:** Inline documentation in [fleet_filters.py](fleet_filters.py)
+- **Python Docstrings:** Inline documentation in [fleet_filters.py](fleet_filters.py) and [apt_filters.py](apt_filters.py)
 - **README:** This file provides usage examples and integration guidance
 
 ## References

--- a/plugins/filter/apt_filters.py
+++ b/plugins/filter/apt_filters.py
@@ -6,12 +6,10 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
-
 DOCUMENTATION = r'''
 ---
 name: apt_version_pin
-version_added: "1.0.0"
+version_added: "1.5.0"
 short_description: Resolve an apt version pin from apt-cache madison output
 description:
     - Picks the full apt version string for a marketing version out of C(apt-cache madison) output.
@@ -63,6 +61,8 @@ _value:
         - C(None) when no line matches the requested version.
     type: str
 '''
+
+import re
 
 # madison prints "<pkg> | <version> | <repo>"; take the middle field.
 _MADISON_LINE = re.compile(r'^[^|]*\|\s*([^|]+?)\s*\|')

--- a/plugins/filter/apt_filters.py
+++ b/plugins/filter/apt_filters.py
@@ -13,7 +13,9 @@ version_added: "1.5.0"
 short_description: Resolve an apt version pin from apt-cache madison output
 description:
     - Picks the full apt version string for a marketing version out of C(apt-cache madison) output.
-    - apt matches an C(=) pin against the full version string, which carries an optional epoch and a distro release suffix, and it does not expand globs in that pin.
+    - apt matches an C(=) pin against the full version string, which carries an
+      optional epoch and a distro release suffix, and it does not expand globs
+      in that pin.
     - A bare pin such as C(docker-ce=29.7.2) therefore never resolves, and neither does C(docker-ce=*29.7.2-*); only the string madison prints does.
     - Returns C(None) when the version is not in the repository, so the calling task can fail with a readable message instead of a Python traceback.
 options:
@@ -27,7 +29,10 @@ options:
     version:
         description:
             - The marketing version to resolve, for example C(29.7.2) or C(5.4.0).
-            - Matched on C((^|:)<version>-) so the version either opens the string or follows the epoch colon, and the trailing hyphen keeps C(29.7.1) from taking C(29.7.10) and rejects a bare prefix like C(29.7).
+            - Matched on C((^|:)<version>-) so the version either opens the
+              string or follows the epoch colon, and the trailing hyphen keeps
+              C(29.7.1) from taking C(29.7.10) and rejects a bare prefix like
+              C(29.7).
             - Dots are matched literally, so C(5.4.0) does not also match a C(5X4X0) build.
         type: str
         required: true

--- a/plugins/filter/apt_filters.py
+++ b/plugins/filter/apt_filters.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024-2026, Arillso
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import re
+
+DOCUMENTATION = r'''
+---
+name: apt_version_pin
+version_added: "1.0.0"
+short_description: Resolve an apt version pin from apt-cache madison output
+description:
+    - Picks the full apt version string for a marketing version out of C(apt-cache madison) output.
+    - apt matches an C(=) pin against the full version string, which carries an optional epoch and a distro release suffix, and it does not expand globs in that pin.
+    - A bare pin such as C(docker-ce=29.7.2) therefore never resolves, and neither does C(docker-ce=*29.7.2-*); only the string madison prints does.
+    - Returns C(None) when the version is not in the repository, so the calling task can fail with a readable message instead of a Python traceback.
+options:
+    _input:
+        description:
+            - Lines of C(apt-cache madison <package>) output, typically C(stdout_lines) of the command.
+            - Each line looks like C(<package> | <version> | <repository>); only the middle field is read.
+        type: list
+        elements: str
+        required: true
+    version:
+        description:
+            - The marketing version to resolve, for example C(29.7.2) or C(5.4.0).
+            - Matched on C((^|:)<version>-) so the version either opens the string or follows the epoch colon, and the trailing hyphen keeps C(29.7.1) from taking C(29.7.10) and rejects a bare prefix like C(29.7).
+            - Dots are matched literally, so C(5.4.0) does not also match a C(5X4X0) build.
+        type: str
+        required: true
+author:
+    - Arillso
+notes:
+    - The filter never raises on a missing version; the readable error belongs in an C(ansible.builtin.fail) task.
+'''
+
+EXAMPLES = r'''
+# Resolve the exact apt version string before pinning it
+- name: Resolve the apt version string for the pin
+  ansible.builtin.command:
+      cmd: apt-cache madison docker-compose-plugin
+  register: compose_madison
+  changed_when: false
+
+- name: Set the resolved apt version string
+  ansible.builtin.set_fact:
+      docker_compose_v2_apt_version: >-
+          {{ compose_madison.stdout_lines
+             | arillso.container.apt_version_pin(docker_compose_v2_version) }}
+  # Returns e.g. 5.4.0-1~ubuntu.24.04~noble, or None when the repository
+  # no longer carries the version.
+'''
+
+RETURN = r'''
+_value:
+    description:
+        - The full apt version string, epoch and distro suffix included.
+        - C(None) when no line matches the requested version.
+    type: str
+'''
+
+# madison prints "<pkg> | <version> | <repo>"; take the middle field.
+_MADISON_LINE = re.compile(r'^[^|]*\|\s*([^|]+?)\s*\|')
+
+
+def apt_version_pin(lines, version):
+    """
+    Resolve the full apt version string for a marketing version.
+
+    Args:
+        lines: Lines of `apt-cache madison <package>` output
+        version: The marketing version to look for, e.g. "5.4.0"
+
+    Returns:
+        The full version string, or None when the version is not offered
+    """
+    if not lines or not version:
+        return None
+
+    # The version either opens the string or follows the epoch colon. The
+    # trailing hyphen keeps 29.7.1 from taking 29.7.10 and rejects a bare
+    # prefix like "29.7"; re.escape keeps the dots literal, without it
+    # "5.4.0" would also match a "5X4X0" build.
+    wanted = re.compile(r'(^|:)' + re.escape(str(version)) + r'-')
+
+    for line in lines:
+        match = _MADISON_LINE.match(line)
+        if not match:
+            continue
+        candidate = match.group(1)
+        if wanted.search(candidate):
+            return candidate
+
+    return None
+
+
+class FilterModule:
+    """Ansible filter module for apt version pinning."""
+
+    def filters(self):
+        return {
+            'apt_version_pin': apt_version_pin,
+        }

--- a/roles/docker/tasks/install_docker_debian.yml
+++ b/roles/docker/tasks/install_docker_debian.yml
@@ -48,8 +48,9 @@
 # 29.7.1 from taking 29.7.10 and rejects a bare prefix like "29.7". docker-ce
 # currently always carries an epoch, but docker-compose-plugin in the same
 # repository does not, so the epoch is matched as optional rather than
-# assumed. regex_escape keeps the dots literal; without it "29.7.1" would
-# also match a "29X7X1" build.
+# assumed. The matching lives in the apt_version_pin filter, which keeps the
+# regex out of YAML -- in a bare `when:` Jinja consumes its backslashes
+# differently and silently turns the guard below into a no-op.
 - name: "Debian : resolve the apt version string for the pin"
   ansible.builtin.command:
       cmd: apt-cache madison docker-ce
@@ -57,16 +58,12 @@
   changed_when: false
   when: docker_version != ''
 
-# The match is resolved inside {{ }} rather than in a bare `when:`, because
-# `when` evaluates its argument as raw Jinja and consumes the backslashes of
-# the regex differently, which silently turns the guard below into a no-op.
-- name: "Debian : collect the matching apt version strings"
+- name: "Debian : set the resolved apt version string"
   ansible.builtin.set_fact:
-      docker_apt_candidates: >-
+      docker_apt_version: >-
           {{ docker_madison.stdout_lines
-             | map('regex_replace', '^[^|]*\|\s*([^|]+?)\s*\|.*$', '\1')
-             | select('search', '(^|:)' ~ (docker_version | regex_escape) ~ '-')
-             | list }}
+             | arillso.container.apt_version_pin(docker_version)
+             | default('', true) }}
   when: docker_version != ''
 
 - name: "Debian : fail when the pinned docker version is not in the repository"
@@ -79,9 +76,4 @@
           the release is removed.
   when:
       - docker_version != ''
-      - docker_apt_candidates | length == 0
-
-- name: "Debian : set the resolved apt version string"
-  ansible.builtin.set_fact:
-      docker_apt_version: "{{ docker_apt_candidates | first }}"
-  when: docker_version != ''
+      - docker_apt_version | length == 0

--- a/roles/docker/tasks/install_docker_ubuntu.yml
+++ b/roles/docker/tasks/install_docker_ubuntu.yml
@@ -60,8 +60,9 @@
 # 29.7.1 from taking 29.7.10 and rejects a bare prefix like "29.7". docker-ce
 # currently always carries an epoch, but docker-compose-plugin in the same
 # repository does not, so the epoch is matched as optional rather than
-# assumed. regex_escape keeps the dots literal; without it "29.7.1" would
-# also match a "29X7X1" build.
+# assumed. The matching lives in the apt_version_pin filter, which keeps the
+# regex out of YAML -- in a bare `when:` Jinja consumes its backslashes
+# differently and silently turns the guard below into a no-op.
 - name: "Ubuntu : resolve the apt version string for the pin"
   ansible.builtin.command:
       cmd: apt-cache madison docker-ce
@@ -69,16 +70,12 @@
   changed_when: false
   when: docker_version != ''
 
-# The match is resolved inside {{ }} rather than in a bare `when:`, because
-# `when` evaluates its argument as raw Jinja and consumes the backslashes of
-# the regex differently, which silently turns the guard below into a no-op.
-- name: "Ubuntu : collect the matching apt version strings"
+- name: "Ubuntu : set the resolved apt version string"
   ansible.builtin.set_fact:
-      docker_apt_candidates: >-
+      docker_apt_version: >-
           {{ docker_madison.stdout_lines
-             | map('regex_replace', '^[^|]*\|\s*([^|]+?)\s*\|.*$', '\1')
-             | select('search', '(^|:)' ~ (docker_version | regex_escape) ~ '-')
-             | list }}
+             | arillso.container.apt_version_pin(docker_version)
+             | default('', true) }}
   when: docker_version != ''
 
 - name: "Ubuntu : fail when the pinned docker version is not in the repository"
@@ -91,9 +88,4 @@
           the release is removed.
   when:
       - docker_version != ''
-      - docker_apt_candidates | length == 0
-
-- name: "Ubuntu : set the resolved apt version string"
-  ansible.builtin.set_fact:
-      docker_apt_version: "{{ docker_apt_candidates | first }}"
-  when: docker_version != ''
+      - docker_apt_version | length == 0

--- a/roles/docker_compose_v2/defaults/main.yml
+++ b/roles/docker_compose_v2/defaults/main.yml
@@ -1,8 +1,11 @@
 ---
 # renovate: datasource=github-releases depName=docker/compose
 docker_compose_v2_version: "5.4.0"
-docker_compose_v2_packages:
-    - name: "{{ 'docker-compose-plugin=' + docker_compose_v2_version if docker_compose_v2_version != '' else 'docker-compose-plugin' }}"
+# docker_compose_v2_packages is intentionally not defined here: the pin form
+# differs per package manager (apt needs the full version string resolved at
+# runtime, dnf needs "pkg-version*"), so it lives in vars/<distribution>.yml,
+# which tasks/main.yml loads before the packages run. A default here would win
+# over those vars and reintroduce the broken single form.
 docker_compose_v2_directory_path: "/etc/docker/compose"
 docker_compose_v2_directory: "{{ docker_compose_v2_directory_path }}/{{ docker_compose_v2_project }}"
 docker_compose_v2_use_file: true

--- a/roles/docker_compose_v2/meta/argument_specs.yml
+++ b/roles/docker_compose_v2/meta/argument_specs.yml
@@ -21,7 +21,9 @@ argument_specs:
                 description:
                     - List of Docker Compose packages for installation. Appends the specified version to the package name if docker_compose_v2_version is set.
                     - Useful for ensuring consistency across environments by locking to a specific version.
-                    - Carries no default here on purpose. The pin form differs per package manager, so it is set in vars/<distribution>.yml, which tasks/main.yml loads before the packages run. A default in this spec would win over those vars.
+                    - Carries no default here on purpose. The pin form differs per package manager,
+                      so it is set in vars/<distribution>.yml, which tasks/main.yml loads before
+                      the packages run. A default in this spec would win over those vars.
 
             docker_compose_v2_directory_path:
                 type: str

--- a/roles/docker_compose_v2/meta/argument_specs.yml
+++ b/roles/docker_compose_v2/meta/argument_specs.yml
@@ -21,8 +21,7 @@ argument_specs:
                 description:
                     - List of Docker Compose packages for installation. Appends the specified version to the package name if docker_compose_v2_version is set.
                     - Useful for ensuring consistency across environments by locking to a specific version.
-                default:
-                    - name: "{{ 'docker-compose-plugin=' + docker_compose_v2_version if docker_compose_v2_version != '' else 'docker-compose-plugin' }}"
+                    - Carries no default here on purpose. The pin form differs per package manager, so it is set in vars/<distribution>.yml, which tasks/main.yml loads before the packages run. A default in this spec would win over those vars.
 
             docker_compose_v2_directory_path:
                 type: str

--- a/roles/docker_compose_v2/molecule/default/converge.yml
+++ b/roles/docker_compose_v2/molecule/default/converge.yml
@@ -3,11 +3,12 @@
   hosts: all
   become: true
   vars:
-      # Do not pin the plugin version: the pin is built as a bare
-      # `docker-compose-plugin=<version>`, which apt matches against the full
-      # version string (epoch and distro suffix) and therefore never resolves.
-      # The docker role resolves that string at runtime; this role does not
-      # yet, so an empty version installs whatever the repo currently offers.
+      # Do not pin the plugin version. The role does resolve the pin at
+      # runtime now (tasks/resolve_apt_version.yml), so a pin would work --
+      # but Docker drops old releases from its repository, which would break
+      # this scenario on a schedule nobody controls. The pinned branch is
+      # covered by the apt_version_pin unit tests instead; an empty version
+      # installs whatever the repo currently offers.
       docker_compose_v2_version: ""
       docker_compose_v2_project: "molecule"
       # Deploy a minimal compose project from a templated file so we

--- a/roles/docker_compose_v2/molecule/default/verify.yml
+++ b/roles/docker_compose_v2/molecule/default/verify.yml
@@ -60,9 +60,8 @@
             name: arillso.container.docker_compose_v2
         vars:
             # Must match converge.yml: the role's install task runs on every
-            # include, and apt has no candidate for an exact
-            # docker-compose-plugin=<version> on the CI image, so a pinned
-            # version would fail here before reaching state=absent.
+            # include, so a version that converge.yml does not also set would
+            # reinstall the plugin here before reaching state=absent.
             docker_compose_v2_version: ""
             docker_compose_v2_project: "molecule"
             docker_compose_v2_use_file: true

--- a/roles/docker_compose_v2/tasks/main.yml
+++ b/roles/docker_compose_v2/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+- name: Add OS specific variables
+  ansible.builtin.include_vars: "{{ loop_vars }}"
+  with_first_found:
+      - files:
+            - "{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
+            - "{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+            - "{{ ansible_facts['distribution'] }}.yml"
+            - "{{ ansible_facts['os_family'] }}.yml"
+            - "{{ ansible_facts['system'] }}.yml"
+            - "defaults.yml"
+        paths:
+            - "vars"
+  loop_control:
+      loop_var: loop_vars
+
 - name: Install the Docker Compose packages
   ansible.builtin.include_tasks: packages.yml
 

--- a/roles/docker_compose_v2/tasks/packages.yml
+++ b/roles/docker_compose_v2/tasks/packages.yml
@@ -1,6 +1,15 @@
 ---
 # Docker Compose package installation and target directory
 
+# Only apt needs the lookup: the unpinned branch installs whatever the
+# repository offers, and dnf expands the wildcard suffix in vars/RedHat.yml
+# by itself.
+- name: Resolve the pinned apt version
+  ansible.builtin.include_tasks: resolve_apt_version.yml
+  when:
+      - docker_compose_v2_version != ''
+      - ansible_facts['pkg_mgr'] in ['apt']
+
 - name: Install Docker Compose packages
   become: true
   ansible.builtin.package:

--- a/roles/docker_compose_v2/tasks/resolve_apt_version.yml
+++ b/roles/docker_compose_v2/tasks/resolve_apt_version.yml
@@ -1,0 +1,31 @@
+---
+# apt matches an "=" pin against the full version string (distro suffix, and an
+# epoch where the package carries one) and does not expand globs in it, so the
+# exact candidate has to be looked up on the host. The matching itself lives in
+# the apt_version_pin filter, which returns the full string or none -- keeping
+# the regex out of YAML, where a bare `when:` would consume its backslashes and
+# silently turn the guard below into a no-op.
+
+- name: Resolve the apt version string for the pin
+  ansible.builtin.command:
+      cmd: apt-cache madison docker-compose-plugin
+  register: docker_compose_v2_madison
+  changed_when: false
+
+- name: Set the resolved apt version string
+  ansible.builtin.set_fact:
+      docker_compose_v2_apt_version: >-
+          {{ docker_compose_v2_madison.stdout_lines
+             | arillso.container.apt_version_pin(docker_compose_v2_version)
+             | default('', true) }}
+
+- name: Fail when the pinned Docker Compose version is not in the repository
+  ansible.builtin.fail:
+      msg: >-
+          docker_compose_v2_version {{ docker_compose_v2_version }} is not
+          available as a docker-compose-plugin package for
+          {{ ansible_facts['distribution'] }}
+          {{ ansible_facts['distribution_release'] }}. Docker drops old
+          packages from its repository, so an exact pin stops resolving once
+          the release is removed.
+  when: docker_compose_v2_apt_version | length == 0

--- a/roles/docker_compose_v2/vars/Debian.yml
+++ b/roles/docker_compose_v2/vars/Debian.yml
@@ -1,0 +1,11 @@
+---
+# apt matches "docker-compose-plugin=<x>" against the *full* version string,
+# which carries a distro release suffix (e.g. 5.4.0-1~debian.12~bookworm), so a
+# bare "docker-compose-plugin=5.4.0" never matches. apt does not evaluate globs
+# in an "=" pin either -- "docker-compose-plugin=*5.4.0-*" fails with "Version
+# not found" -- so the full string is resolved at runtime from apt-cache madison
+# into docker_compose_v2_apt_version (see tasks/resolve_apt_version.yml) and
+# pinned exactly. The RedHat pin cannot share this: dnf rejects the "=" syntax
+# outright and takes the wildcard suffix instead.
+docker_compose_v2_packages:
+    - name: "{{ 'docker-compose-plugin=' + docker_compose_v2_apt_version if docker_compose_v2_version != '' else 'docker-compose-plugin' }}"

--- a/roles/docker_compose_v2/vars/RedHat.yml
+++ b/roles/docker_compose_v2/vars/RedHat.yml
@@ -1,0 +1,10 @@
+---
+# Covers the whole RedHat family (Rocky, AlmaLinux, RHEL, CentOS) via the
+# os_family fallback in tasks/main.yml. dnf does not know the apt "pkg=version"
+# syntax at all and expects "pkg-version"; RPM version strings additionally
+# carry a release part (e.g. <version>-1.el9), which a bare
+# "docker-compose-plugin-<version>" never matches, so the pin uses a wildcard
+# suffix. dnf expands that glob, apt does not -- which is why the Debian and
+# Ubuntu vars resolve the exact string at runtime instead.
+docker_compose_v2_packages:
+    - name: "{{ 'docker-compose-plugin-' + docker_compose_v2_version + '*' if docker_compose_v2_version != '' else 'docker-compose-plugin' }}"

--- a/roles/docker_compose_v2/vars/Ubuntu.yml
+++ b/roles/docker_compose_v2/vars/Ubuntu.yml
@@ -1,0 +1,11 @@
+---
+# apt matches "docker-compose-plugin=<x>" against the *full* version string,
+# which carries a distro release suffix (e.g. 5.4.0-1~ubuntu.24.04~noble), so a
+# bare "docker-compose-plugin=5.4.0" never matches. apt does not evaluate globs
+# in an "=" pin either -- "docker-compose-plugin=*5.4.0-*" fails with "Version
+# not found" -- so the full string is resolved at runtime from apt-cache madison
+# into docker_compose_v2_apt_version (see tasks/resolve_apt_version.yml) and
+# pinned exactly. The RedHat pin cannot share this: dnf rejects the "=" syntax
+# outright and takes the wildcard suffix instead.
+docker_compose_v2_packages:
+    - name: "{{ 'docker-compose-plugin=' + docker_compose_v2_apt_version if docker_compose_v2_version != '' else 'docker-compose-plugin' }}"

--- a/roles/docker_compose_v2/vars/defaults.yml
+++ b/roles/docker_compose_v2/vars/defaults.yml
@@ -1,0 +1,4 @@
+---
+# Last entry of the with_first_found chain in tasks/main.yml. Deliberately
+# empty: a distribution that reaches this file has no known pin form, and
+# guessing one would install a wrong package instead of failing visibly.

--- a/tests/unit/plugins/filter/test_apt_filters.py
+++ b/tests/unit/plugins/filter/test_apt_filters.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024-2026, Arillso
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+"""Unit tests for apt_filters plugin.
+
+The fixtures are real `apt-cache madison` output: docker-ce carries an epoch,
+docker-compose-plugin does not, and both live in the same Docker repository.
+"""
+
+import sys
+from pathlib import Path
+
+# Add the plugins directory to the path
+plugins_path = Path(__file__).parent.parent.parent.parent.parent / "plugins" / "filter"
+sys.path.insert(0, str(plugins_path))
+
+from apt_filters import apt_version_pin  # noqa: E402
+
+# `apt-cache madison docker-compose-plugin` on Ubuntu 24.04 (no epoch).
+COMPOSE_MADISON = [
+    " docker-compose-plugin | 5.4.0-1~ubuntu.24.04~noble | "
+    "https://download.docker.com/linux/ubuntu noble/stable amd64 Packages",
+    " docker-compose-plugin | 5.3.0-1~ubuntu.24.04~noble | "
+    "https://download.docker.com/linux/ubuntu noble/stable amd64 Packages",
+]
+
+# `apt-cache madison docker-ce` on Ubuntu 24.04 (epoch "5:").
+DOCKER_MADISON = [
+    " docker-ce | 5:29.7.10-1~ubuntu.24.04~noble | "
+    "https://download.docker.com/linux/ubuntu noble/stable amd64 Packages",
+    " docker-ce | 5:29.7.2-1~ubuntu.24.04~noble | "
+    "https://download.docker.com/linux/ubuntu noble/stable amd64 Packages",
+    " docker-ce | 5:29.7.1-1~ubuntu.24.04~noble | "
+    "https://download.docker.com/linux/ubuntu noble/stable amd64 Packages",
+]
+
+
+def test_version_without_epoch_resolves_to_the_full_string():
+    """docker-compose-plugin carries no epoch, so the version opens the string."""
+    assert apt_version_pin(COMPOSE_MADISON, "5.4.0") == "5.4.0-1~ubuntu.24.04~noble"
+
+
+def test_version_with_epoch_keeps_the_epoch():
+    """apt matches the pin against the full string, epoch included."""
+    assert apt_version_pin(DOCKER_MADISON, "29.7.2") == "5:29.7.2-1~ubuntu.24.04~noble"
+
+
+def test_shorter_version_does_not_take_the_longer_one():
+    """The trailing hyphen keeps 29.7.1 from resolving to 29.7.10."""
+    assert apt_version_pin(DOCKER_MADISON, "29.7.1") == "5:29.7.1-1~ubuntu.24.04~noble"
+
+
+def test_bare_prefix_does_not_resolve():
+    """"29.7" is not a release; without the hyphen guard it would take one."""
+    assert apt_version_pin(DOCKER_MADISON, "29.7") is None
+
+
+def test_dots_are_literal():
+    """Without regex escaping "5.4.0" would also match a "5X4X0" build."""
+    weird = [
+        " docker-compose-plugin | 5X4X0-1~ubuntu.24.04~noble | "
+        "https://download.docker.com/linux/ubuntu noble/stable amd64 Packages",
+    ]
+    assert apt_version_pin(weird, "5.4.0") is None
+
+
+def test_version_missing_from_the_repository_returns_none():
+    """Docker drops old packages, so a pin stops resolving at some point."""
+    assert apt_version_pin(COMPOSE_MADISON, "5.0.0") is None
+
+
+def test_empty_line_list_returns_none():
+    """A madison call that printed nothing must not raise."""
+    assert apt_version_pin([], "5.4.0") is None
+
+
+def test_empty_version_returns_none():
+    """The unpinned branch never calls the filter, but it must not match all."""
+    assert apt_version_pin(COMPOSE_MADISON, "") is None

--- a/tests/unit/test_el_support.py
+++ b/tests/unit/test_el_support.py
@@ -223,26 +223,103 @@ def test_apt_tasks_resolve_the_pin_and_fail_loudly(tasks_file):
     assert "apt-cache madison docker-ce" in text, tasks_file
     assert "docker_apt_version:" in text, tasks_file
     assert "ansible.builtin.fail:" in text, tasks_file
-    # the match must anchor on "(^|:)<version>-" so 29.7.1 cannot take
-    # 29.7.10 and a package without an epoch still resolves, and regex_escape
-    # must keep the dots from matching arbitrary characters
-    assert "regex_escape" in text, tasks_file
-    assert "'(^|:)' ~ (docker_version | regex_escape) ~ '-'" in text, tasks_file
+    # The match lives in the filter, which anchors on "(^|:)<version>-" and
+    # escapes the dots. Hand-rolling it in Jinja again is the defect this
+    # replaced: a regex in YAML loses its backslashes in a bare `when:`.
+    assert "arillso.container.apt_version_pin(docker_version)" in text, tasks_file
+    assert "regex_replace" not in text, tasks_file
+    assert "docker_apt_candidates" not in text, tasks_file
 
-    # The regex must be evaluated inside {{ }}, never in a bare `when:`: there
-    # Jinja consumes the backslashes differently, the select matches nothing
-    # and the guard degrades into a no-op that fails every pinned run.
-    in_when = False
-    when_indent = 0
-    for line in text.splitlines():
-        if not line.strip():
-            continue
-        indent = len(line) - len(line.lstrip())
-        if in_when and indent <= when_indent and not line.lstrip().startswith("-"):
-            in_when = False
-        if in_when:
-            assert "regex_replace" not in line, (
-                f"{tasks_file}: regex evaluated in a bare when: -- {line.strip()}"
-            )
-        if line.lstrip().startswith("when:"):
-            in_when, when_indent = True, indent
+
+@pytest.mark.parametrize("vars_file", ["Debian.yml", "Ubuntu.yml"])
+def test_compose_apt_vars_pin_uses_the_resolved_full_version(vars_file):
+    """Same defect as docker-ce: apt matches an "=" pin against the full
+    version string, so only the runtime-resolved value can be pinned."""
+    text = read("roles", "docker_compose_v2", "vars", vars_file)
+    entries = [
+        line.strip().lstrip("-").strip()
+        for line in text.splitlines()
+        if line.strip().startswith("-")
+    ]
+    assert any("'docker-compose-plugin=' + docker_compose_v2_apt_version" in e for e in entries), (
+        entries
+    )
+    # a bare pin on the marketing version is the original defect
+    assert not any("'docker-compose-plugin=' + docker_compose_v2_version" in e for e in entries), (
+        entries
+    )
+    # apt rejects a glob inside an "=" pin
+    assert not any("docker-compose-plugin=*" in e for e in entries), entries
+
+
+def test_compose_redhat_vars_pin_uses_rpm_compatible_syntax():
+    """dnf does not know the apt "pkg=version" syntax at all and RPM version
+    strings carry a release part, so the pin needs "pkg-version*"."""
+    text = read("roles", "docker_compose_v2", "vars", "RedHat.yml")
+    entries = [
+        line.strip().lstrip("-").strip()
+        for line in text.splitlines()
+        if line.strip().startswith("-")
+    ]
+    assert any("docker-compose-plugin-' + docker_compose_v2_version + '*" in e for e in entries), (
+        entries
+    )
+    # apt syntax in a RedHat vars file would break dnf
+    assert not any("docker-compose-plugin=" in e for e in entries), entries
+
+
+def test_compose_defaults_define_no_package_pin():
+    """A default for docker_compose_v2_packages outranks the distro vars and
+    would reinstate the single broken pin form for every package manager."""
+    for parts in (
+        ("roles", "docker_compose_v2", "defaults", "main.yml"),
+        ("roles", "docker_compose_v2", "meta", "argument_specs.yml"),
+    ):
+        text = read(*parts)
+        entries = [
+            line.strip().lstrip("-").strip()
+            for line in text.splitlines()
+            if line.strip().startswith("-")
+        ]
+        assert not any("docker-compose-plugin" in e for e in entries), (
+            f"{'/'.join(parts)} still pins a package: {entries}"
+        )
+
+
+def test_compose_resolves_the_apt_pin_and_fails_loudly():
+    """The resolution must run, and a version the repository no longer
+    carries must fail with a message instead of installing anything."""
+    text = read("roles", "docker_compose_v2", "tasks", "resolve_apt_version.yml")
+    assert "apt-cache madison docker-compose-plugin" in text
+    assert "arillso.container.apt_version_pin(docker_compose_v2_version)" in text
+    assert "ansible.builtin.fail:" in text
+    assert "regex_replace" not in text
+
+    # dnf expands the wildcard itself and the unpinned branch needs no lookup,
+    # so the madison call has to stay guarded to a pinned apt run.
+    packages = read("roles", "docker_compose_v2", "tasks", "packages.yml")
+    assert "resolve_apt_version.yml" in packages
+    assert "docker_compose_v2_version != ''" in packages
+    assert "ansible_facts['pkg_mgr'] in ['apt']" in packages
+
+
+def test_compose_loads_the_os_specific_vars():
+    """Without the include_vars, docker_compose_v2_packages is undefined and
+    the install loop dies -- the defaults no longer carry it."""
+    text = read("roles", "docker_compose_v2", "tasks", "main.yml")
+    assert "ansible.builtin.include_vars:" in text
+    assert "with_first_found:" in text
+
+    facts = ROCKY_FACTS
+    vars_hit = first_found(
+        "roles/docker_compose_v2/vars",
+        [
+            f"{facts['distribution']}-{facts['distribution_version']}.yml",
+            f"{facts['distribution']}-{facts['distribution_major_version']}.yml",
+            f"{facts['distribution']}.yml",
+            f"{facts['os_family']}.yml",
+            f"{facts['system']}.yml",
+            "defaults.yml",
+        ],
+    )
+    assert vars_hit == "RedHat.yml", f"Rocky resolved compose vars to {vars_hit}"


### PR DESCRIPTION
## Summary

- `docker_compose_v2` built a single `docker-compose-plugin=<version>` pin for three package managers. apt matches an `=` pin against the *full* version string (distro suffix, and an epoch where present) and does not expand globs in it, so the pin never resolved; dnf does not know that syntax at all, although the role advertises EL 9. Every pinned run failed, and CI missed it because the scenario only tests the unpinned branch.
- The pin form now lives in `roles/docker_compose_v2/vars/{Debian,Ubuntu,RedHat,defaults}.yml`, loaded via the same `with_first_found` block the `docker` role uses. apt resolves the exact string at runtime and fails loudly when the repository no longer carries the version; dnf keeps the wildcard suffix it does expand.
- The matching moved into a new `apt_version_pin` filter, replacing four hand-rolled Jinja regex copies (two of them added for `docker-ce` in #169). Keeping the regex out of YAML also removes the `when:`-backslash failure mode as a class.
- The version value `5.4.0` and its Renovate annotation are unchanged — only the pin *form* was broken.

## Test plan

- [x] `pytest tests/unit/` — 72 passed, including 8 new `apt_version_pin` cases built from real madison output (with and without epoch, `29.7.1` not taking `29.7.10`, bare prefix rejected, literal dots, version absent, empty inputs)
- [x] Static guards extended: the apt vars must pin the resolved value, `RedHat.yml` must stay dnf-compatible, neither `defaults/main.yml` nor `meta/argument_specs.yml` may reintroduce a package default, and the madison lookup must stay guarded to a pinned apt run
- [x] `ansible-lint --offline --profile=production` and `yamllint .` clean
- [ ] Molecule stays on the unpinned branch on purpose: pinning it would tie CI to a version Docker can drop from its repository at any time