### PR TITLE
chore(renovate): disable updates for molecule-qemu

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,10 @@
         {
             "matchPackageNames": ["ansible-core"],
             "enabled": false
+        },
+        {
+            "matchPackageNames": ["molecule-qemu"],
+            "enabled": false
         }
     ],
     "customManagers": [


### PR DESCRIPTION
## Summary

- Disable Renovate updates for `molecule-qemu`, which Renovate reports as abandoned (last release 2024-10-28)
- Mirrors the existing `ansible-core` rule; the pin stays until a maintained replacement exists

## Test plan

- [ ] CI green (renovate-config-validator / lint)
