### PR TITLE
fix(k3s): unload and remove AppArmor profile when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **k3s AppArmor profile survived being disabled**: setting
+  `k3s_apparmor_profile` to `false` only stopped
+  `roles/k3s/tasks/security.yml` from writing `/etc/apparmor.d/k3s`; a copy
+  left from an earlier run stayed on disk and was reloaded by
+  `apparmor.service` on every boot, so turning the variable off never took
+  effect on hosts that once had it on. The role now mirrors the cri-containerd
+  disable path — it unloads the profile with `apparmor_parser -R`, removes the
+  file and clears a hand-placed `/etc/apparmor.d/disable/k3s` symlink. With the
+  profile still loaded, container processes ran under stacked child profiles,
+  so `kubectl exec` failed with an AppArmor `operation not permitted` error and
+  pods hung in Terminating with `FailedKillPod`. The load task also read
+  `k3s_apparmor_profile | default(true)` where the deploy task read
+  `default(false)`; both now use `default(false)`.
+
 - **k3s server nodes ignored container log rotation**: the
   `container-log-max-size` and `container-log-max-files` kubelet args were only
   built by `agent-config.yaml.j2`, so a server node never rotated container

--- a/roles/k3s/meta/argument_specs.yml
+++ b/roles/k3s/meta/argument_specs.yml
@@ -486,7 +486,11 @@ argument_specs:
             k3s_apparmor_profile:
                 type: "bool"
                 default: false
-                description: "Apply AppArmor profile for K3s"
+                description: >-
+                    Deploy and load the K3s AppArmor profile.
+                    When false, any existing profile is unloaded and removed,
+                    along with a hand-placed /etc/apparmor.d/disable/k3s
+                    symlink.
 
             k3s_cri_apparmor_profile_enabled:
                 type: "bool"

--- a/roles/k3s/molecule/default/prepare.yml
+++ b/roles/k3s/molecule/default/prepare.yml
@@ -1,0 +1,35 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+      # converge leaves k3s_apparmor_profile unset, so the role default
+      # (false) applies and the disable path runs. Plant the leftovers that
+      # path is meant to clean up — without them the role finds nothing,
+      # skips every cleanup task and verify.yml would pass trivially on a
+      # host that never had the profile.
+      - name: Ensure the AppArmor profile directories exist
+        ansible.builtin.file:
+            path: "{{ item }}"
+            state: directory
+            mode: "0755"
+        loop:
+            - /etc/apparmor.d
+            - /etc/apparmor.d/disable
+
+      - name: Plant a leftover K3s AppArmor profile
+        ansible.builtin.copy:
+            content: |
+                #include <tunables/global>
+
+                /usr/local/bin/k3s flags=(attach_disconnected,mediate_deleted,complain) {
+                  #include <abstractions/base>
+                }
+            dest: /etc/apparmor.d/k3s
+            mode: "0644"
+
+      - name: Plant a hand-made K3s AppArmor disable symlink
+        ansible.builtin.file:
+            src: /etc/apparmor.d/k3s
+            dest: /etc/apparmor.d/disable/k3s
+            state: link

--- a/roles/k3s/molecule/default/prepare.yml
+++ b/roles/k3s/molecule/default/prepare.yml
@@ -8,28 +8,39 @@
       # path is meant to clean up — without them the role finds nothing,
       # skips every cleanup task and verify.yml would pass trivially on a
       # host that never had the profile.
-      - name: Ensure the AppArmor profile directories exist
-        ansible.builtin.file:
-            path: "{{ item }}"
-            state: directory
-            mode: "0755"
-        loop:
-            - /etc/apparmor.d
-            - /etc/apparmor.d/disable
+      #
+      # Gated on the same fact the role's AppArmor block uses
+      # (`k3s_security_framework == "apparmor"` in tasks/security.yml), so
+      # this only runs where the cleanup path runs. On a SELinux host the
+      # block never executes, and a profile planted there would simply stay
+      # on disk.
+      - name: Plant a leftover K3s AppArmor profile and disable symlink
+        when: >-
+            ansible_facts['apparmor'] is defined
+            and ansible_facts['apparmor']['status'] == "enabled"
+        block:
+            - name: Ensure the AppArmor profile directories exist
+              ansible.builtin.file:
+                  path: "{{ item }}"
+                  state: directory
+                  mode: "0755"
+              loop:
+                  - /etc/apparmor.d
+                  - /etc/apparmor.d/disable
 
-      - name: Plant a leftover K3s AppArmor profile
-        ansible.builtin.copy:
-            content: |
-                #include <tunables/global>
+            - name: Plant a leftover K3s AppArmor profile
+              ansible.builtin.copy:
+                  content: |
+                      #include <tunables/global>
 
-                /usr/local/bin/k3s flags=(attach_disconnected,mediate_deleted,complain) {
-                  #include <abstractions/base>
-                }
-            dest: /etc/apparmor.d/k3s
-            mode: "0644"
+                      /usr/local/bin/k3s flags=(attach_disconnected,mediate_deleted,complain) {
+                        #include <abstractions/base>
+                      }
+                  dest: /etc/apparmor.d/k3s
+                  mode: "0644"
 
-      - name: Plant a hand-made K3s AppArmor disable symlink
-        ansible.builtin.file:
-            src: /etc/apparmor.d/k3s
-            dest: /etc/apparmor.d/disable/k3s
-            state: link
+            - name: Plant a hand-made K3s AppArmor disable symlink
+              ansible.builtin.file:
+                  src: /etc/apparmor.d/k3s
+                  dest: /etc/apparmor.d/disable/k3s
+                  state: link

--- a/roles/k3s/molecule/default/prepare.yml
+++ b/roles/k3s/molecule/default/prepare.yml
@@ -16,7 +16,9 @@
       # on disk.
       - name: Plant a leftover K3s AppArmor profile and disable symlink
         when: >-
-            ansible_facts['apparmor'] is defined
+            not (ansible_facts['selinux']['status'] is defined
+            and ansible_facts['selinux']['status'] != "disabled")
+            and ansible_facts['apparmor'] is defined
             and ansible_facts['apparmor']['status'] == "enabled"
         block:
             - name: Ensure the AppArmor profile directories exist

--- a/roles/k3s/molecule/default/verify.yml
+++ b/roles/k3s/molecule/default/verify.yml
@@ -294,3 +294,37 @@
         environment:
             KUBECONFIG: /etc/rancher/k3s/k3s.yaml
         changed_when: true
+
+      # converge.yml leaves k3s_apparmor_profile unset, so the role default
+      # (false) applies and the disable path runs. Assert it actually cleans
+      # up: a leftover profile is reloaded on every boot and breaks `kubectl
+      # exec` and pod termination.
+      - name: Check the K3s AppArmor profile file is gone
+        ansible.builtin.stat:
+            path: /etc/apparmor.d/k3s
+        register: k3s_apparmor_profile_stat
+
+      - name: Check the K3s AppArmor disable symlink is gone
+        ansible.builtin.stat:
+            path: /etc/apparmor.d/disable/k3s
+        register: k3s_apparmor_disable_stat
+
+      - name: Search the kernel for a loaded K3s AppArmor profile
+        ansible.builtin.command:
+            cmd: grep -qE '^/usr/local/bin/k3s' /sys/kernel/security/apparmor/profiles
+        register: k3s_apparmor_kernel_match
+        changed_when: false
+        failed_when: false
+
+      - name: Verify the disabled K3s AppArmor profile is removed
+        ansible.builtin.assert:
+            that:
+                - not k3s_apparmor_profile_stat.stat.exists
+                - not k3s_apparmor_disable_stat.stat.exists
+                - k3s_apparmor_kernel_match.rc != 0
+            fail_msg: >-
+                k3s_apparmor_profile is off, but the profile is still present:
+                file={{ k3s_apparmor_profile_stat.stat.exists }},
+                disable symlink={{ k3s_apparmor_disable_stat.stat.exists }},
+                loaded in kernel={{ k3s_apparmor_kernel_match.rc == 0 }}
+            success_msg: "Disabled K3s AppArmor profile is removed and unloaded"

--- a/roles/k3s/molecule/default/verify.yml
+++ b/roles/k3s/molecule/default/verify.yml
@@ -308,7 +308,9 @@
       # platform the change never touches.
       - name: Assert the AppArmor cleanup on AppArmor hosts
         when: >-
-            ansible_facts['apparmor'] is defined
+            not (ansible_facts['selinux']['status'] is defined
+            and ansible_facts['selinux']['status'] != "disabled")
+            and ansible_facts['apparmor'] is defined
             and ansible_facts['apparmor']['status'] == "enabled"
         block:
             - name: Check the K3s AppArmor profile file is gone

--- a/roles/k3s/molecule/default/verify.yml
+++ b/roles/k3s/molecule/default/verify.yml
@@ -296,9 +296,10 @@
         changed_when: true
 
       # converge.yml leaves k3s_apparmor_profile unset, so the role default
-      # (false) applies and the disable path runs. Assert it actually cleans
-      # up: a leftover profile is reloaded on every boot and breaks `kubectl
-      # exec` and pod termination.
+      # (false) applies and the disable path runs. prepare.yml plants a
+      # leftover profile and disable symlink beforehand, so this exercises the
+      # cleanup rather than a host that never had the profile: a leftover is
+      # reloaded on every boot and breaks `kubectl exec` and pod termination.
       - name: Check the K3s AppArmor profile file is gone
         ansible.builtin.stat:
             path: /etc/apparmor.d/k3s
@@ -309,22 +310,37 @@
             path: /etc/apparmor.d/disable/k3s
         register: k3s_apparmor_disable_stat
 
+      # securityfs is absent where AppArmor is not enabled (Rocky), which is
+      # not the same as "the profile is unloaded" - assert the two apart
+      # instead of letting an unreadable path count as a pass.
+      - name: Check whether the kernel exposes AppArmor profiles
+        ansible.builtin.stat:
+            path: /sys/kernel/security/apparmor/profiles
+        register: k3s_apparmor_securityfs
+
       - name: Search the kernel for a loaded K3s AppArmor profile
         ansible.builtin.command:
             cmd: grep -qE '^/usr/local/bin/k3s' /sys/kernel/security/apparmor/profiles
         register: k3s_apparmor_kernel_match
         changed_when: false
         failed_when: false
+        when: k3s_apparmor_securityfs.stat.exists
 
       - name: Verify the disabled K3s AppArmor profile is removed
         ansible.builtin.assert:
             that:
                 - not k3s_apparmor_profile_stat.stat.exists
                 - not k3s_apparmor_disable_stat.stat.exists
-                - k3s_apparmor_kernel_match.rc != 0
+                # rc 1 is "no match", rc 2 is a grep error - only the former
+                # proves the profile is not loaded.
+                - >-
+                    not k3s_apparmor_securityfs.stat.exists
+                    or k3s_apparmor_kernel_match.rc == 1
             fail_msg: >-
-                k3s_apparmor_profile is off, but the profile is still present:
+                k3s_apparmor_profile is off, but the profile is still present
+                or the check could not run:
                 file={{ k3s_apparmor_profile_stat.stat.exists }},
                 disable symlink={{ k3s_apparmor_disable_stat.stat.exists }},
-                loaded in kernel={{ k3s_apparmor_kernel_match.rc == 0 }}
+                securityfs={{ k3s_apparmor_securityfs.stat.exists }},
+                grep rc={{ k3s_apparmor_kernel_match.rc | default('skipped') }}
             success_msg: "Disabled K3s AppArmor profile is removed and unloaded"

--- a/roles/k3s/molecule/default/verify.yml
+++ b/roles/k3s/molecule/default/verify.yml
@@ -300,47 +300,58 @@
       # leftover profile and disable symlink beforehand, so this exercises the
       # cleanup rather than a host that never had the profile: a leftover is
       # reloaded on every boot and breaks `kubectl exec` and pod termination.
-      - name: Check the K3s AppArmor profile file is gone
-        ansible.builtin.stat:
-            path: /etc/apparmor.d/k3s
-        register: k3s_apparmor_profile_stat
+      #
+      # The role gates its whole AppArmor block on
+      # `k3s_security_framework == "apparmor"`, so on a SELinux host (Rocky)
+      # neither prepare nor the cleanup path runs and there is nothing to
+      # assert. Same fact, same guard, or the assertions would fail on a
+      # platform the change never touches.
+      - name: Assert the AppArmor cleanup on AppArmor hosts
+        when: >-
+            ansible_facts['apparmor'] is defined
+            and ansible_facts['apparmor']['status'] == "enabled"
+        block:
+            - name: Check the K3s AppArmor profile file is gone
+              ansible.builtin.stat:
+                  path: /etc/apparmor.d/k3s
+              register: k3s_apparmor_profile_stat
 
-      - name: Check the K3s AppArmor disable symlink is gone
-        ansible.builtin.stat:
-            path: /etc/apparmor.d/disable/k3s
-        register: k3s_apparmor_disable_stat
+            - name: Check the K3s AppArmor disable symlink is gone
+              ansible.builtin.stat:
+                  path: /etc/apparmor.d/disable/k3s
+              register: k3s_apparmor_disable_stat
 
-      # securityfs is absent where AppArmor is not enabled (Rocky), which is
-      # not the same as "the profile is unloaded" - assert the two apart
-      # instead of letting an unreadable path count as a pass.
-      - name: Check whether the kernel exposes AppArmor profiles
-        ansible.builtin.stat:
-            path: /sys/kernel/security/apparmor/profiles
-        register: k3s_apparmor_securityfs
+            # An unreadable securityfs is not the same as "the profile is
+            # unloaded": grep exits 2 on error and 1 on no match, so assert
+            # the two apart instead of letting a check that could not run
+            # count as a pass.
+            - name: Check whether the kernel exposes AppArmor profiles
+              ansible.builtin.stat:
+                  path: /sys/kernel/security/apparmor/profiles
+              register: k3s_apparmor_securityfs
 
-      - name: Search the kernel for a loaded K3s AppArmor profile
-        ansible.builtin.command:
-            cmd: grep -qE '^/usr/local/bin/k3s' /sys/kernel/security/apparmor/profiles
-        register: k3s_apparmor_kernel_match
-        changed_when: false
-        failed_when: false
-        when: k3s_apparmor_securityfs.stat.exists
+            - name: Search the kernel for a loaded K3s AppArmor profile
+              ansible.builtin.command:
+                  cmd: >-
+                      grep -qE '^/usr/local/bin/k3s'
+                      /sys/kernel/security/apparmor/profiles
+              register: k3s_apparmor_kernel_match
+              changed_when: false
+              failed_when: false
+              when: k3s_apparmor_securityfs.stat.exists
 
-      - name: Verify the disabled K3s AppArmor profile is removed
-        ansible.builtin.assert:
-            that:
-                - not k3s_apparmor_profile_stat.stat.exists
-                - not k3s_apparmor_disable_stat.stat.exists
-                # rc 1 is "no match", rc 2 is a grep error - only the former
-                # proves the profile is not loaded.
-                - >-
-                    not k3s_apparmor_securityfs.stat.exists
-                    or k3s_apparmor_kernel_match.rc == 1
-            fail_msg: >-
-                k3s_apparmor_profile is off, but the profile is still present
-                or the check could not run:
-                file={{ k3s_apparmor_profile_stat.stat.exists }},
-                disable symlink={{ k3s_apparmor_disable_stat.stat.exists }},
-                securityfs={{ k3s_apparmor_securityfs.stat.exists }},
-                grep rc={{ k3s_apparmor_kernel_match.rc | default('skipped') }}
-            success_msg: "Disabled K3s AppArmor profile is removed and unloaded"
+            - name: Verify the disabled K3s AppArmor profile is removed
+              ansible.builtin.assert:
+                  that:
+                      - not k3s_apparmor_profile_stat.stat.exists
+                      - not k3s_apparmor_disable_stat.stat.exists
+                      - k3s_apparmor_securityfs.stat.exists
+                      - k3s_apparmor_kernel_match.rc == 1
+                  fail_msg: >-
+                      k3s_apparmor_profile is off, but the profile is still
+                      present or the check could not run:
+                      file={{ k3s_apparmor_profile_stat.stat.exists }},
+                      disable symlink={{ k3s_apparmor_disable_stat.stat.exists }},
+                      securityfs={{ k3s_apparmor_securityfs.stat.exists }},
+                      grep rc={{ k3s_apparmor_kernel_match.rc | default('skipped') }}
+                  success_msg: "Disabled K3s AppArmor profile is removed and unloaded"

--- a/roles/k3s/tasks/security.yml
+++ b/roles/k3s/tasks/security.yml
@@ -317,9 +317,59 @@
         ansible.builtin.command: apparmor_parser -r /etc/apparmor.d/k3s
         become: true
         when:
-            - k3s_apparmor_profile | default(true) | bool
+            - k3s_apparmor_profile | default(false) | bool
             - _k3s_apparmor_profile_created is changed
         changed_when: true
+
+      # Disable path: remove any previously deployed k3s profile. The deploy
+      # task above only stops writing the file; a copy left from an earlier run
+      # is reloaded by apparmor.service on every boot, so switching the variable
+      # off never took effect on existing hosts.
+      # Stacked child profiles (/usr/local/bin/k3s//null-/runc//null-*) block
+      # runc from writing /proc/thread-self/attr/apparmor/exec and from
+      # signalling container init: `kubectl exec` fails with "operation not
+      # permitted" and pods hang in Terminating with FailedKillPod. Observed on
+      # Ubuntu 24.04, kernel 6.8.0-137 - the same failure the cri-containerd
+      # disable path above addresses for kernel 6.17, so it is not limited to
+      # that version.
+      - name: Stat existing K3s AppArmor profile
+        ansible.builtin.stat:
+            path: /etc/apparmor.d/k3s
+        register: _k3s_apparmor_profile_file
+        when: not (k3s_apparmor_profile | default(false) | bool)
+
+      - name: Unload K3s AppArmor profile from kernel
+        ansible.builtin.command:
+            cmd: apparmor_parser -R /etc/apparmor.d/k3s
+        become: true
+        when:
+            - not (k3s_apparmor_profile | default(false) | bool)
+            - _k3s_apparmor_profile_file.stat.exists | default(false)
+        register: _k3s_apparmor_profile_unloaded
+        changed_when: _k3s_apparmor_profile_unloaded.rc == 0
+        failed_when: false
+        notify: Restart k3s
+
+      - name: Remove K3s AppArmor profile file
+        ansible.builtin.file:
+            path: /etc/apparmor.d/k3s
+            state: absent
+        become: true
+        when:
+            - not (k3s_apparmor_profile | default(false) | bool)
+            - _k3s_apparmor_profile_file.stat.exists | default(false)
+        notify: Restart k3s
+
+      # A hand-placed disable symlink keeps the profile from loading even once
+      # the file is gone; left behind it silently masks whether re-enabling the
+      # variable works. The role never creates it, so this only cleans up
+      # manual workarounds.
+      - name: Remove K3s AppArmor disable symlink
+        ansible.builtin.file:
+            path: /etc/apparmor.d/disable/k3s
+            state: absent
+        become: true
+        when: not (k3s_apparmor_profile | default(false) | bool)
 
 # General Security Hardening
 # K3s configuration directory permissions are set during directory creation in main.yml


### PR DESCRIPTION
## Summary

- `k3s_apparmor_profile: false` only stopped the role from writing `/etc/apparmor.d/k3s`. A profile left from an earlier run stayed on disk and `apparmor.service` reloaded it on every boot, so switching the variable off never took effect on hosts that once had it on.
- The role now mirrors the existing cri-containerd disable path: stat, `apparmor_parser -R`, remove the file, and additionally clear a hand-placed `/etc/apparmor.d/disable/k3s` symlink. Unload runs before remove, because `apparmor_parser -R` reads the file to determine which kernel profile to unload.
- The load task read `k3s_apparmor_profile | default(true)` while the deploy task read `default(false)`. Harmless today because the second condition covers it, but a trap for the next reader — both now use `default(false)`.
- With the profile loaded, container processes run under stacked child profiles (`/usr/local/bin/k3s//null-/runc//null-*`), which blocks runc from writing `/proc/thread-self/attr/apparmor/exec` and from signalling container init: `kubectl exec` fails with `operation not permitted` and pods hang in Terminating with `FailedKillPod`. Observed on Ubuntu 24.04 with kernel 6.8.0-137, so this is not limited to the kernel 6.17 bug the cri-containerd path addresses.
- The molecule scenario gained a `prepare.yml` that plants a leftover profile and disable symlink, so the new verify assertions exercise the cleanup path rather than a host that never had the profile.

## Test plan

- [x] `make lint-yaml` and `ansible-lint` (profile `production`) clean on the changed files
- [x] `prettier` and `markdownlint` clean (pre-commit hooks)
- [x] `molecule-k3s / Molecule (default)` green in CI across Ubuntu 22.04, Debian 12 and Rocky 9, including `idempotence`
- [x] All other CI checks green, including the secret scanners
