### PR TITLE
refactor(fleet): make bundle readiness wait configurable

### DIFF
--- a/roles/fleet/defaults/main.yml
+++ b/roles/fleet/defaults/main.yml
@@ -92,6 +92,16 @@ fleet_dry_run: false
 fleet_secret_timeout: 60
 fleet_resource_timeout: 300
 
+# Whether "Manage Fleet Bundles" blocks until each Bundle reports Ready.
+# Bundles are applied in a serial loop, so with wait enabled the play time
+# grows with the number of bundles (up to fleet_bundle_wait_timeout each).
+# Set false (globally, or per bundle via `wait: false` on the item) to apply
+# stable bundles fire-and-forget and let Fleet reconcile them asynchronously,
+# trading the readiness gate for a much shorter run. Mirrors the per-item
+# wait handling already used in clusters.yml.
+fleet_bundle_wait: true
+fleet_bundle_wait_timeout: 300
+
 # Fleet authentication parameters (auth entry point) are intentionally left
 # undefined here. They are declared as optional in meta/argument_specs.yml and
 # resolved with default(omit) where consumed, so no string-omit defaults are set.

--- a/roles/fleet/defaults/main.yml
+++ b/roles/fleet/defaults/main.yml
@@ -97,8 +97,8 @@ fleet_resource_timeout: 300
 # grows with the number of bundles (up to fleet_bundle_wait_timeout each).
 # Set false (globally, or per bundle via `wait: false` on the item) to apply
 # stable bundles fire-and-forget and let Fleet reconcile them asynchronously,
-# trading the readiness gate for a much shorter run. Mirrors the per-item
-# wait handling already used in clusters.yml.
+# trading the readiness gate for a much shorter run. Clusters gate their wait
+# on kubeconfig_secret instead and have no equivalent knob.
 fleet_bundle_wait: true
 fleet_bundle_wait_timeout: 300
 

--- a/roles/fleet/meta/argument_specs.yml
+++ b/roles/fleet/meta/argument_specs.yml
@@ -58,6 +58,14 @@
                 "description": "Enable dry-run mode for Fleet operations"
                 "type": "bool"
                 "default": false
+            "fleet_bundle_wait":
+                "description": "Whether Manage Fleet Bundles waits for each Bundle to report Ready (per-bundle overridable via the bundle's wait key)"
+                "type": "bool"
+                "default": true
+            "fleet_bundle_wait_timeout":
+                "description": "Default seconds to wait for a Bundle to report Ready when waiting is enabled"
+                "type": "int"
+                "default": 300
             "fleet_secret_timeout":
                 "description": "Timeout in seconds for secret operations"
                 "type": "int"
@@ -228,6 +236,12 @@
                         "description": "Pause Bundle deployment"
                         "type": "bool"
                         "default": false
+                    "wait":
+                        "description": "Wait for the Bundle to report Ready (overrides fleet_bundle_wait)"
+                        "type": "bool"
+                    "wait_timeout":
+                        "description": "Seconds to wait for Ready when wait is enabled (overrides fleet_bundle_wait_timeout)"
+                        "type": "int"
                     "keep_resources":
                         "description": "Keep resources when Bundle is deleted"
                         "type": "bool"

--- a/roles/fleet/tasks/bundles.yml
+++ b/roles/fleet/tasks/bundles.yml
@@ -89,11 +89,12 @@
       # role never sent (spec.targetCustomizationMode), which no amount
       # of omitting on our side can match.
       apply: true
-      wait: true
-      wait_condition:
-          type: Ready
-          status: "True"
-      wait_timeout: 300
+      # Per-bundle override of the readiness gate, falling back to the role
+      # default. When wait is false the Bundle is applied without blocking on
+      # Ready, so a long serial loop no longer stacks up wait_timeout per item.
+      wait: "{{ item.wait | default(fleet_bundle_wait) | bool }}"
+      wait_condition: "{{ {'type': 'Ready', 'status': 'True'} if (item.wait | default(fleet_bundle_wait) | bool) else omit }}"
+      wait_timeout: "{{ item.wait_timeout | default(fleet_bundle_wait_timeout) | int if (item.wait | default(fleet_bundle_wait) | bool) else omit }}"
   loop: "{{ fleet_bundles }}"
   when: fleet_bundles | length > 0
   register: fleet_bundle_results

--- a/roles/fleet/tasks/bundles.yml
+++ b/roles/fleet/tasks/bundles.yml
@@ -25,6 +25,11 @@
 # does not support async"). That path could never run — only check_mode ever
 # reached the synchronous fallback.
 - name: "Manage Fleet Bundles"
+  vars:
+      # Resolved once so wait, wait_condition and wait_timeout below cannot
+      # drift apart: a true wait with an omitted condition would block on mere
+      # existence instead of Ready=True.
+      _bundle_wait: "{{ item.wait | default(fleet_bundle_wait) | bool }}"
   kubernetes.core.k8s:
       kubeconfig: "{{ fleet_kubeconfig_path | default('/etc/rancher/k3s/k3s.yaml') }}"
       definition:
@@ -92,9 +97,9 @@
       # Per-bundle override of the readiness gate, falling back to the role
       # default. When wait is false the Bundle is applied without blocking on
       # Ready, so a long serial loop no longer stacks up wait_timeout per item.
-      wait: "{{ item.wait | default(fleet_bundle_wait) | bool }}"
-      wait_condition: "{{ {'type': 'Ready', 'status': 'True'} if (item.wait | default(fleet_bundle_wait) | bool) else omit }}"
-      wait_timeout: "{{ item.wait_timeout | default(fleet_bundle_wait_timeout) | int if (item.wait | default(fleet_bundle_wait) | bool) else omit }}"
+      wait: "{{ _bundle_wait | bool }}"
+      wait_condition: "{{ {'type': 'Ready', 'status': 'True'} if (_bundle_wait | bool) else omit }}"
+      wait_timeout: "{{ item.wait_timeout | default(fleet_bundle_wait_timeout) | int if (_bundle_wait | bool) else omit }}"
   loop: "{{ fleet_bundles }}"
   when: fleet_bundles | length > 0
   register: fleet_bundle_results


### PR DESCRIPTION
## Summary

- Make the Bundle readiness gate configurable via `fleet_bundle_wait` / `fleet_bundle_wait_timeout`, with per-bundle `wait` / `wait_timeout` overrides
- `bundles.yml` applied every Bundle with a hardcoded `wait: true` / `wait_timeout: 300` in a serial loop, so run time grew by up to the timeout per bundle with no way to opt out
- Defaults keep the current behaviour; when waiting is off, `wait_condition` and `wait_timeout` are omitted

## Test plan

- [ ] CI green
- [x] `ansible-lint roles/fleet/` passes (production profile)
- [x] Template expressions rendered for all four cases: default, per-bundle `wait: false`, per-bundle `wait_timeout`, global `fleet_bundle_wait=false`
