### PR TITLE
fix(renovate): parse molecule image lines instead of comments

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,20 @@
             ],
             "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}",
             "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+        },
+        {
+            "description": [
+                "Digest-pinned images in Molecule scenario playbooks. The shared preset only parses `image:` in molecule.yml, so the images embedded in converge.yml/verify.yml need their own manager. Parsing the line directly keeps depName as the repository and currentValue as the bare tag; a `# renovate:` comment would instead be matched by the comment manager in renovate-base, which captures `nginx:alpine` as the tag and makes the registry return 400 DIGEST_INVALID. The digest is required in the match so that throwaway test images pinned by tag alone (registry:2 in docker_login) stay untracked."
+            ],
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^roles/[^/]+/molecule/[^/]+/(converge|verify|prepare|side_effect|cleanup)\\.yml$/"
+            ],
+            "datasourceTemplate": "docker",
+            "versioningTemplate": "docker",
+            "matchStrings": [
+                "image:\\s*[\"']?(?<depName>[^:\\s\"']+):(?<currentValue>[^@\\s\"']+?)@(?<currentDigest>sha256:[a-f0-9]+)[\"']?\\s*(?:\\r?\\n|\\r|$)"
+            ]
         }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renovate could not refresh the pinned nginx digest**: the `image:` lines in
+  `roles/docker_compose_v2/molecule/default/converge.yml` and `verify.yml`
+  carried a `# renovate: datasource=docker depName=nginx` comment, which the
+  comment manager from the shared `renovate-base` preset read as
+  `currentValue: nginx:alpine`. The resulting request for the
+  `library/nginx:nginx:alpine` manifest returned `400 DIGEST_INVALID` and every
+  Renovate run reported "Could not determine new digest for update" as a
+  repository problem, leaving the digest frozen. The comments are gone and
+  `.github/renovate.json` gained a `customManager` that parses the `image:`
+  line itself, so `depName` is `nginx`, `currentValue` is `alpine` and the
+  digest updates again. The match requires an `@sha256:` suffix, which keeps
+  tag-only test images such as `registry:2` in `docker_login` untracked.
+
 - **k3s AppArmor profile survived being disabled**: setting
   `k3s_apparmor_profile` to `false` only stopped
   `roles/k3s/tasks/security.yml` from writing `/etc/apparmor.d/k3s`; a copy

--- a/roles/docker_compose_v2/molecule/default/converge.yml
+++ b/roles/docker_compose_v2/molecule/default/converge.yml
@@ -23,7 +23,12 @@
                   # tag resolves to a different ID than the stored one, compose
                   # recreates the container even though the config hash still
                   # matches, and the idempotence step fails on the launch task.
-                  # renovate: datasource=docker depName=nginx versioning=docker
+                  # Renovate keeps the digest fresh through the molecule-image
+                  # customManager in .github/renovate.json, which parses this
+                  # `image:` line directly. A `# renovate:` comment here would
+                  # be picked up by the comment manager in the shared preset
+                  # instead, which reads the whole `nginx:alpine` as the tag
+                  # and fails the registry lookup.
                   image: nginx:alpine@sha256:1d40e3eb3bf4f138de1d67193f2aa5309fcaf343eb5ffadbf5e9439de1eb1ebb
                   ports:
                       - "8080:80"

--- a/roles/docker_compose_v2/molecule/default/verify.yml
+++ b/roles/docker_compose_v2/molecule/default/verify.yml
@@ -72,8 +72,9 @@
                     web:
                         # Must match converge.yml: the role renders this into
                         # the project file, and compose resolves the project to
-                        # tear down from it.
-                        # renovate: datasource=docker depName=nginx versioning=docker
+                        # tear down from it. Renovate updates the digest here
+                        # through the molecule-image customManager in
+                        # .github/renovate.json.
                         image: nginx:alpine@sha256:1d40e3eb3bf4f138de1d67193f2aa5309fcaf343eb5ffadbf5e9439de1eb1ebb
                         ports:
                             - "8080:80"


### PR DESCRIPTION
## Summary

- The `# renovate:` comments above the digest-pinned nginx images in
  `roles/docker_compose_v2/molecule/default/{converge,verify}.yml` were picked up
  by the comment manager from `renovate-base`, which read the whole `nginx:alpine`
  as the tag. Every run requested the `library/nginx:nginx:alpine` manifest, got
  `400 DIGEST_INVALID` back and reported "Could not determine new digest for
  update" as a repository problem, leaving the pinned digest frozen.
- The comments are gone and `.github/renovate.json` gained a `customManager` that
  parses the `image:` line directly, so `depName` is `nginx` and `currentValue` is
  `alpine`. The preset's Molecule manager only covers `molecule.yml`, so the images
  embedded in the scenario playbooks need their own manager.
- The match requires an `@sha256:` suffix, which keeps tag-only throwaway images
  such as `registry:2` in `docker_login` untracked instead of proposing major bumps
  for them.

## Test plan

- [ ] The regex was run against all 25 `roles/*/molecule/*/*.yml` files: exactly the
      two nginx lines match, split into `nginx` / `alpine` / digest; `registry:2` no
      longer matches.
- [ ] `yamllint`, `ansible-lint` (production profile, 21 files) and `prettier` pass.
- [ ] CI green.
- [ ] `renovate-config-validator` was not run locally — it crashes on Node 26 in a
      transitive dependency (`buffer-equal-constant-time`, `SlowBuffer` removed) and
      no container runtime was available. JSON syntax is validated, the schema is not.
