### PR TITLE
fix(renovate): match digest-only and port-qualified images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,7 +27,7 @@
         },
         {
             "description": [
-                "Digest-pinned images in Molecule scenario playbooks. The shared preset only parses `image:` in molecule.yml, so the images embedded in converge.yml/verify.yml need their own manager. Parsing the line directly keeps depName as the repository and currentValue as the bare tag; a `# renovate:` comment would instead be matched by the comment manager in renovate-base, which captures `nginx:alpine` as the tag and makes the registry return 400 DIGEST_INVALID. The digest is required in the match so that throwaway test images pinned by tag alone (registry:2 in docker_login) stay untracked."
+                "Digest-pinned images in Molecule scenario playbooks. The shared preset only parses `image:` in molecule.yml, so the images embedded in converge.yml/verify.yml need their own manager. Parsing the line directly keeps depName as the repository and currentValue as the bare tag; a `# renovate:` comment would instead be matched by the comment manager in renovate-base, which captures `nginx:alpine` as the tag and makes the registry return 400 DIGEST_INVALID. The digest is required in the match so that throwaway test images pinned by tag alone (registry:2 in docker_login) stay untracked, while the tag itself is optional so a digest-only pin is still picked up. Excluding `/` from the tag keeps a port-qualified registry (registry.example.com:5000/nginx) inside depName instead of splitting it at the port."
             ],
             "customType": "regex",
             "managerFilePatterns": [
@@ -36,7 +36,7 @@
             "datasourceTemplate": "docker",
             "versioningTemplate": "docker",
             "matchStrings": [
-                "image:\\s*[\"']?(?<depName>[^:\\s\"']+):(?<currentValue>[^@\\s\"']+?)@(?<currentDigest>sha256:[a-f0-9]+)[\"']?\\s*(?:\\r?\\n|\\r|$)"
+                "image:\\s*[\"']?(?<depName>[^\\s\"'@]+?)(?::(?<currentValue>[^@\\s\"'/]+))?@(?<currentDigest>sha256:[a-f0-9]+)[\"']?\\s*(?:\\r?\\n|\\r|$)"
             ]
         }
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.github/renovate.json` gained a `customManager` that parses the `image:`
   line itself, so `depName` is `nginx`, `currentValue` is `alpine` and the
   digest updates again. The match requires an `@sha256:` suffix, which keeps
-  tag-only test images such as `registry:2` in `docker_login` untracked.
+  tag-only test images such as `registry:2` in `docker_login` untracked, while
+  the tag itself is optional so a digest-only pin (`image: nginx@sha256:…`) is
+  still tracked rather than silently frozen. Excluding `/` from the tag keeps a
+  port-qualified registry (`registry.example.com:5000/nginx`) inside `depName`
+  instead of splitting it at the port.
 
 - **k3s AppArmor profile survived being disabled**: setting
   `k3s_apparmor_profile` to `false` only stopped


### PR DESCRIPTION
## Summary

- Follow-up to #196, addressing the two non-blocking review nits on the Molecule
  image matcher. Both describe cases the matcher gets wrong today; neither occurs
  in the repo yet.
- The matcher required a `:tag`, so a digest-only pin (`image: nginx@sha256:…`)
  did not match at all. Renovate would skip it silently and freeze the digest —
  the exact failure class #196 was opened to fix. The tag group is now optional.
- `depName` was captured with `[^:\s"']+`, stopping at the first colon. A registry
  with an explicit port (`registry.example.com:5000/nginx:alpine@sha256:…`) would
  yield `depName=registry.example.com` and fold host and path into the tag,
  producing a wrong Docker datasource lookup. Excluding `/` from the tag group
  keeps the port inside `depName`.

## Test plan

- [ ] The regex was run from the actual config against all 25
      `roles/*/molecule/*/*.yml` files: the two nginx lines still resolve to
      `nginx` / `alpine` / digest, unchanged from #196.
- [ ] Seven constructed cases pass: tag+digest, digest-only, port-registry with
      and without tag, `ghcr.io` path with quotes — all split correctly;
      `registry:2` and `nginx:alpine` (no digest) still do not match.
- [ ] CI green.
- [ ] `renovate-config-validator` was not run locally — it crashes on Node 26 in a
      transitive dependency (`buffer-equal-constant-time`, `SlowBuffer` removed)
      and no container runtime was available. JSON syntax is validated, the schema
      is not.
