### PR TITLE
ci: run the CI matrix on Python 3.14

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -25,7 +25,7 @@ jobs:
             collection_namespace: arillso
             collection_name: container
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
-            python_version: "3.13"
+            python_version: "3.14"
             enable_unit_tests: true
 
     security-secrets:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
     ci:
-        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: container
@@ -29,4 +29,4 @@ jobs:
             enable_unit_tests: true
 
     security-secrets:
-        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-17

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -22,21 +22,21 @@ permissions:
 
 jobs:
     codeql:
-        uses: arillso/.github/.github/workflows/security-codeql.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-codeql.yml@2026-08-17
         with:
             language: python
 
     security-secrets:
-        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-17
 
     security-config:
-        uses: arillso/.github/.github/workflows/security-config.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-config.yml@2026-08-17
         with:
             scan-ansible: true
             ansible-path: roles
 
     security-sbom:
-        uses: arillso/.github/.github/workflows/security-sbom.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-sbom.yml@2026-08-17
         with:
             artifact-type: filesystem
             artifact-ref: "."

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,7 +27,7 @@ jobs:
             collection_namespace: arillso
             collection_name: container
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
-            python_version: "3.13"
+            python_version: "3.14"
             enable_unit_tests: true
 
     molecule-docker:
@@ -44,7 +44,7 @@ jobs:
             collection_name: container
             driver: qemu
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
-            python_version: "3.13"
+            python_version: "3.14"
             scenarios_root: roles/docker/molecule
             scenarios: '["default"]'
             concurrency-suffix: molecule-docker
@@ -56,7 +56,7 @@ jobs:
             collection_name: container
             driver: qemu
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
-            python_version: "3.13"
+            python_version: "3.14"
             scenarios_root: roles/k3s/molecule
             scenarios: '["default"]'
             concurrency-suffix: molecule-k3s
@@ -68,7 +68,7 @@ jobs:
             collection_name: container
             driver: qemu
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
-            python_version: "3.13"
+            python_version: "3.14"
             scenarios_root: roles/docker_login/molecule
             scenarios: '["default"]'
             concurrency-suffix: molecule-docker-login
@@ -80,7 +80,7 @@ jobs:
             collection_name: container
             driver: qemu
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
-            python_version: "3.13"
+            python_version: "3.14"
             scenarios_root: roles/docker_compose_v2/molecule
             scenarios: '["default"]'
             concurrency-suffix: molecule-docker-compose-v2
@@ -92,7 +92,7 @@ jobs:
             collection_name: container
             driver: qemu
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
-            python_version: "3.13"
+            python_version: "3.14"
             scenarios_root: roles/helm/molecule
             scenarios: '["default"]'
             concurrency-suffix: molecule-helm
@@ -104,7 +104,7 @@ jobs:
             collection_name: container
             driver: qemu
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
-            python_version: "3.13"
+            python_version: "3.14"
             scenarios_root: roles/fleet/molecule
             scenarios: '["default"]'
             concurrency-suffix: molecule-fleet
@@ -116,7 +116,7 @@ jobs:
             collection_name: container
             driver: qemu
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
-            python_version: "3.13"
+            python_version: "3.14"
             scenarios_root: roles/tailscale/molecule
             scenarios: '["default"]'
             concurrency-suffix: molecule-tailscale

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
     ci:
-        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: container
@@ -38,7 +38,7 @@ jobs:
         # the matrix is pinned to the single `default` scenario. The
         # concurrency-suffix keeps each role's nested call out of the
         # caller's concurrency group.
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: container
@@ -50,7 +50,7 @@ jobs:
             concurrency-suffix: molecule-docker
 
     molecule-k3s:
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: container
@@ -62,7 +62,7 @@ jobs:
             concurrency-suffix: molecule-k3s
 
     molecule-docker-login:
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: container
@@ -74,7 +74,7 @@ jobs:
             concurrency-suffix: molecule-docker-login
 
     molecule-docker-compose-v2:
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: container
@@ -86,7 +86,7 @@ jobs:
             concurrency-suffix: molecule-docker-compose-v2
 
     molecule-helm:
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: container
@@ -98,7 +98,7 @@ jobs:
             concurrency-suffix: molecule-helm
 
     molecule-fleet:
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: container
@@ -110,7 +110,7 @@ jobs:
             concurrency-suffix: molecule-fleet
 
     molecule-tailscale:
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: container
@@ -122,12 +122,12 @@ jobs:
             concurrency-suffix: molecule-tailscale
 
     security-secrets:
-        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-17
 
     security-deps:
-        uses: arillso/.github/.github/workflows/security-deps.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-deps.yml@2026-08-17
 
     claude-review:
-        uses: arillso/.github/.github/workflows/ai-claude-review.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ai-claude-review.yml@2026-08-17
         secrets:
             CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
     release:
-        uses: arillso/.github/.github/workflows/release-ansible-collection.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/release-ansible-collection.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI now runs on Python 3.14**: the nine `python_version` inputs in
+  `.github/workflows/pull-request.yml` and `.github/workflows/merge.yml` moved
+  from `3.13` to `3.14`, matching `.python-version`.
+- **Reusable workflow references pinned to `2026-08-17`**: all 18 calls to
+  `arillso/.github` moved off `2026-08-16`. The bump is a prerequisite for the
+  change above — the older reusable pinned the sanity job to Python 3.12 for
+  `stable-2.20` and `devel` and ignored the caller's `python_version`, so
+  raising the input alone would have had no effect.
+
 ## [2.0.0] - 2026-08-16
 
 ### Removed


### PR DESCRIPTION
## Summary

- Raise the nine `python_version` inputs in `pull-request.yml` and `merge.yml` from `3.13` to `3.14`, so CI runs on the interpreter `.python-version` already declares (`3.14.7`).
- Bump all 18 `arillso/.github` reusable references from `2026-08-16` to `2026-08-17`. This is a prerequisite, not a drive-by: the older reusable pinned the sanity job to Python 3.12 for `stable-2.20` and `devel` and discarded the caller's `python_version`, so raising the input alone would have had no effect. The newer reusable derives the controller Python from the ansible-core branch (`stable-2.18`/`2.19` -> 3.13, `stable-2.20`/`devel` -> 3.14).
- Two of the nine inputs feed `ci-ansible-collection.yml`, the other seven feed `ci-ansible-molecule.yml`, where the value only drives `setup-python` and the `pip install`. Raising all nine keeps a single Python version across the repo.

Not included: `.python-version` (already correct at `3.14.7`), the Renovate preset pin, and the `ansible_versions` matrix default.

Risk to watch in this run: the seven QEMU molecule jobs install `molecule`, `molecule-qemu` and `pytest` on 3.14 for the first time. `requirements.txt` only declares lower bounds, so nothing blocks 3.14, but if a package breaks there, all seven jobs fail together.

## Test plan

- [ ] `yamllint .` and `actionlint` pass locally
- [ ] CI green
- [ ] In the sanity job log, the `stable-2.20` matrix row sets up Python 3.14 (not 3.12) — otherwise the ref bump did not take effect